### PR TITLE
Fix implementation of arbitrary kwargs to virtual ports

### DIFF
--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -59,20 +59,16 @@ class HttpClient(object):
         self.url_base = "%s://%s:%s" % (protocol, host, port)
 
     def request(self, method, api_url, params={}, headers=None,
-                file_name=None, file_content=None, **kwargs):
+                file_name=None, file_content=None, axapi_args=None, **kwargs):
         LOG.debug("axapi_http: full url = %s", self.url_base + api_url)
         LOG.debug("axapi_http: %s url = %s", method, api_url)
         LOG.debug("axapi_http: params = %s", json.dumps(params, indent=4))
 
-        # Update params with **kwargs for currently unsupported configuration
-        # of objects
-        formatted_kwargs = dict([(k.replace('_', '-'), v) for k, v in kwargs.iteritems()])
-        param_keys = params.keys()
-        if params != {}:
-            if len(param_keys) != 1:
-                raise KeyError("params must have exactly one key, not {}. "
-                               "params: {}".format(len(param_keys), params))
-            params[param_keys[0]].update(formatted_kwargs)
+        # Update params with axapi_args for currently unsupported configuration of objects
+        if axapi_args is not None:
+            formatted_axapi_args = dict([(k.replace('_', '-'), v) for k, v in
+                                        axapi_args.iteritems()])
+            params.update(formatted_axapi_args)
 
         if (file_name is None and file_content is not None) or \
            (file_name is not None and file_content is None):
@@ -84,10 +80,6 @@ class HttpClient(object):
             hdrs.update(headers)
 
         if params:
-            # FIXME - re-enable kwargs merge at some point; dict keys
-            # between 2.1 and 3.0 do not match, and a10-neutron-lbaas
-            # uses 2.1 wrappers
-            # extra_params = kwargs.get('axapi_args', {})
             params_copy = params.copy()
             # params_copy.update(extra_params)
             LOG.debug("axapi_http: params_all = %s", params_copy)

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -64,6 +64,16 @@ class HttpClient(object):
         LOG.debug("axapi_http: %s url = %s", method, api_url)
         LOG.debug("axapi_http: params = %s", json.dumps(params, indent=4))
 
+        # Update params with **kwargs for currently unsupported configuration
+        # of objects
+        formatted_kwargs = dict([(k.replace('_', '-'), v) for k, v in kwargs.iteritems()])
+        param_keys = params.keys()
+        if params != {}:
+            if len(param_keys) != 1:
+                raise KeyError("params must have exactly one key, not {}. "
+                               "params: {}".format(len(param_keys), params))
+            params[param_keys[0]].update(formatted_kwargs)
+
         if (file_name is None and file_content is not None) or \
            (file_name is not None and file_content is None):
             raise ValueError("file_name and file_content must both be "

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -71,7 +71,7 @@ class VirtualPort(base.BaseV30):
             })
         }
 
-        formatted_kwargs = {k.replace('_', '-'): v for k, v in kwargs.iteritems()}
+        formatted_kwargs = dict([(k.replace('_', '-'), v) for k, v in kwargs.iteritems()])
 
         # Account for extra arguments from people who know what they're doing
         params["port"].update(formatted_kwargs)

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -71,6 +71,10 @@ class VirtualPort(base.BaseV30):
             })
         }
 
+        formatted_kwargs = {k.replace('_', '-'): v for k, v in kwargs.iteritems()}
+
+        params["port"].update(formatted_kwargs)  # account for any extra arguments for people who know what they're doing
+
         url = self.url_server_tmpl.format(name=virtual_server_name)
         if update:
             url += self.url_port_tmpl.format(

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -73,7 +73,8 @@ class VirtualPort(base.BaseV30):
 
         formatted_kwargs = {k.replace('_', '-'): v for k, v in kwargs.iteritems()}
 
-        params["port"].update(formatted_kwargs)  # account for any extra arguments for people who know what they're doing
+        # Account for extra arguments from people who know what they're doing
+        params["port"].update(formatted_kwargs)
 
         url = self.url_server_tmpl.format(name=virtual_server_name)
         if update:

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -71,11 +71,6 @@ class VirtualPort(base.BaseV30):
             })
         }
 
-        formatted_kwargs = dict([(k.replace('_', '-'), v) for k, v in kwargs.iteritems()])
-
-        # Account for extra arguments from people who know what they're doing
-        params["port"].update(formatted_kwargs)
-
         url = self.url_server_tmpl.format(name=virtual_server_name)
         if update:
             url += self.url_port_tmpl.format(


### PR DESCRIPTION
Previously we were accepting **kwargs but not setting them properly in the JSON sent to the AX. This fixes it.

I'm open to discussion on whether we should allow this or not.

Part of me thinks it's better to only accept explicit arguments for our AX objects. The other part sees that these objects have a lot of attributes which can unnecessarily muck up code. It also then becomes a little tedious to add new arguments.

If we decide we want to only allow explicitly stated arguments, we can still this to move forward with working code and open an issue to fix it at a later time. I'd be cool with that.