### PR TITLE
Allow update method to work for ssl-cert/key objects.

### DIFF
--- a/acos_client/v30/file/ssl_cert.py
+++ b/acos_client/v30/file/ssl_cert.py
@@ -30,8 +30,7 @@ class SSLCert(base.BaseV30):
         except acos_errors.NotFound:
             return False
 
-    def _set(self, file="", cert="", size="", certificate_type="",
-             action="", update=False, **kwargs):
+    def _set(self, file="", cert="", size="", certificate_type="", action="", **kwargs):
 
         obj_params = {
             "file": file,
@@ -48,17 +47,14 @@ class SSLCert(base.BaseV30):
             if val != "":
                 kwargs['params']['ssl-cert'][key] = val
 
-        if not update:
-            file = ''
-
-        return self._post(self.url_prefix + file, file_name=obj_params["file"],
+        return self._post(self.url_prefix, file_name=obj_params["file"],
                           file_content=cert, **kwargs)
 
     def create(self, file="", cert="", size="", certificate_type="", action="", **kwargs):
         if self.exists(file):
             raise acos_errors.Exists
 
-        self._set(file, cert, size, certificate_type, action, update=False, **kwargs)
+        self._set(file, cert, size, certificate_type, action, **kwargs)
 
     def update(self, file="", cert="", size="", certificate_type="", action="", **kwargs):
         self._set(file, cert, size, certificate_type, action, update=True, **kwargs)

--- a/acos_client/v30/file/ssl_key.py
+++ b/acos_client/v30/file/ssl_key.py
@@ -30,8 +30,7 @@ class SSLKey(base.BaseV30):
         except acos_errors.NotFound:
             return False
 
-    def _set(self, file="", cert="", size="", action="", update=False,
-             **kwargs):
+    def _set(self, file="", cert="", size="", action="", **kwargs):
 
         obj_params = {
             "file": file,
@@ -47,20 +46,17 @@ class SSLKey(base.BaseV30):
             if val != "":
                 kwargs['params']['ssl-key'][key] = val
 
-        if not update:
-            file = ''
-
-        return self._post(self.url_prefix + file, file_name=obj_params["file"],
+        return self._post(self.url_prefix, file_name=obj_params["file"],
                           file_content=cert, **kwargs)
 
     def create(self, file="", cert="", size="", action=""):
         if self.exists(file):
             raise acos_errors.Exists
 
-        self._set(file, cert, size, action, update=False)
+        self._set(file, cert, size, action)
 
     def update(self, file="", cert="", size="", action=""):
-        self._set(file, cert, size, action, update=True)
+        self._set(file, cert, size, action)
 
     def delete(self, file):
         """This is the very inconsistent way to delete a certificate."""


### PR DESCRIPTION
Strangely enough, the URIs to update ssl certs and ssl keys is the same as the URI to update (this differs from the other 99% of AXAPI flow).