### PR TITLE
Add separate param up-retries to SLB HM

### DIFF
--- a/acos_client/v21/slb/hm.py
+++ b/acos_client/v21/slb/hm.py
@@ -27,7 +27,7 @@ class HealthMonitor(base.BaseV21):
         return self._post("slb.hm.search", {"name": name}, **kwargs)
 
     def _set(self, action, name, mon_type, interval, timeout, max_retries,
-             method=None, url=None, expect_code=None, port=None, **kwargs):
+             up_retries, method=None, url=None, expect_code=None, port=None, **kwargs):
         defs = {
             self.HTTP: {
                 'protocol': 'http',
@@ -45,7 +45,7 @@ class HealthMonitor(base.BaseV21):
         params = {
             'retry': max_retries,
             'name': name,
-            'consec_pass_reqd': max_retries,
+            'consec_pass_reqd': up_retries,
             'interval': interval,
             'timeout': timeout,
             'disable_after_down': 0,
@@ -60,14 +60,14 @@ class HealthMonitor(base.BaseV21):
         self._post(action, params, **kwargs)
 
     def create(self, name, mon_type, interval, timeout, max_retries,
-               method=None, url=None, expect_code=None, port=None, **kwargs):
+               up_retries, method=None, url=None, expect_code=None, port=None, **kwargs):
         self._set("slb.hm.create", name, mon_type, interval, timeout,
-                  max_retries, method, url, expect_code, port, **kwargs)
+                  max_retries, up_retries, method, url, expect_code, port, **kwargs)
 
     def update(self, name, mon_type, interval, timeout, max_retries,
-               method=None, url=None, expect_code=None, port=None, **kwargs):
+               up_retries, method=None, url=None, expect_code=None, port=None, **kwargs):
         self._set("slb.hm.update", name, mon_type, interval, timeout,
-                  max_retries, method, url, expect_code, port, **kwargs)
+                  max_retries, up_retries, method, url, expect_code, port, **kwargs)
 
     def delete(self, name, **kwargs):
         self._post("slb.hm.delete", {"name": name}, **kwargs)

--- a/tests/unit/test_hm.py
+++ b/tests/unit/test_hm.py
@@ -31,21 +31,21 @@ class TestHealthMonitor(unittest.TestCase):
 
     def test_hm_create(self):
         with mocks.HealthMonitorCreate().client() as c:
-            c.slb.hm.create('hm1', 'HTTP', 5, 5, 5, 'GET', '/', '200', 80)
+            c.slb.hm.create('hm1', 'HTTP', 5, 5, 5, 5, 'GET', '/', '200', 80)
 
     def test_hm_create_exists(self):
         with mocks.HealthMonitorCreateExists().client() as c:
             with self.assertRaises(acos_errors.Exists):
-                c.slb.hm.create('hm1', 'HTTP', 5, 5, 5, 'GET', '/', '200', 80)
+                c.slb.hm.create('hm1', 'HTTP', 5, 5, 5, 5, 'GET', '/', '200', 80)
 
     def test_hm_update(self):
         with mocks.HealthMonitorUpdate().client() as c:
-            c.slb.hm.update('hm1', 'HTTP', 5, 5, 5, 'GET', '/', '200', 80)
+            c.slb.hm.update('hm1', 'HTTP', 5, 5, 5, 5, 'GET', '/', '200', 80)
 
     def test_hm_update_not_found(self):
         with mocks.HealthMonitorUpdateNotFound().client() as c:
             with self.assertRaises(acos_errors.NotFound):
-                c.slb.hm.update('hm1', 'HTTP', 5, 5, 5, 'GET', '/', '200', 80)
+                c.slb.hm.update('hm1', 'HTTP', 5, 5, 5, 5, 'GET', '/', '200', 80)
 
     def test_hm_search(self):
         with mocks.HealthMonitorSearch().client() as c:


### PR DESCRIPTION
Add separate param 'up-retries' to SLB Health Monitor so as to specify "Consec Pass Req’d" separately from max "Retry" count.