### PR TITLE
Handles health-check inconsistencies

### DIFF
--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -50,11 +50,12 @@ class ServiceGroup(base.BaseV30):
         return self._get(self.url_prefix + name, **kwargs)
 
     def _set(self, name, protocol=None, lb_method=None, hm_name=None,
-             hm_disable=0, update=False, **kwargs):
+             update=False, **kwargs):
 
         # Normalize "" -> None for json
-        if not hm_name or hm_name == "":
-            hm_name = None
+        hm_name = hm_name or None
+
+        # v30 needs unit tests badly...
 
         params = {
             "service-group": self.minimal_dict({
@@ -63,10 +64,12 @@ class ServiceGroup(base.BaseV30):
             })
         }
 
+        health_check_disable = 1 if kwargs["health_check_disable"] is True else 0
+
         # When enabling/disabling a health monitor, you can't specify
         # health-check-disable and health-check at the same time.
         if hm_name is None:
-            params["service-group"]["health-check-disable"] = 1
+            params["service-group"]["health-check-disable"] = health_check_disable
         else:
             params["service-group"]["health-check"] = hm_name
 
@@ -95,9 +98,9 @@ class ServiceGroup(base.BaseV30):
         self._set(name, protocol, lb_method, **kwargs)
 
     def update(self, name, protocol=None, lb_method=None, health_monitor=None,
-               health_monitor_disable=0, **kwargs):
+               **kwargs):
         self._set(name, protocol, lb_method,
-                  health_monitor, health_monitor_disable, update=True, **kwargs)
+                  health_monitor, update=True, **kwargs)
 
     def delete(self, name):
         self._delete(self.url_prefix + name)

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -50,19 +50,26 @@ class ServiceGroup(base.BaseV30):
         return self._get(self.url_prefix + name, **kwargs)
 
     def _set(self, name, protocol=None, lb_method=None, hm_name=None,
-             update=False, **kwargs):
+             hm_disable=0, update=False, **kwargs):
 
         # Normalize "" -> None for json
-        if not hm_name:
+        if not hm_name or hm_name == "":
             hm_name = None
 
         params = {
             "service-group": self.minimal_dict({
                 "name": name,
                 "protocol": protocol,
-                "health-check": hm_name
             })
         }
+
+        # When enabling/disabling a health monitor, you can't specify
+        # health-check-disable and health-check at the same time.
+        if hm_name is None:
+            params["service-group"]["health-check-disable"] = 1
+        else:
+            params["service-group"]["health-check"] = hm_name
+
         if lb_method is None:
             pass
         elif lb_method[-16:] == 'least-connection':
@@ -88,9 +95,9 @@ class ServiceGroup(base.BaseV30):
         self._set(name, protocol, lb_method, **kwargs)
 
     def update(self, name, protocol=None, lb_method=None, health_monitor=None,
-               **kwargs):
+               health_monitor_disable=0, **kwargs):
         self._set(name, protocol, lb_method,
-                  health_monitor, update=True, **kwargs)
+                  health_monitor, health_monitor_disable, update=True, **kwargs)
 
     def delete(self, name):
         self._delete(self.url_prefix + name)

--- a/acos_client/version.py
+++ b/acos_client/version.py
@@ -12,4 +12,4 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-VERSION = '1.2.5'
+VERSION = '1.2.6'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "acos-client",
-    version = "1.2.5",
+    version = "1.2.6",
     packages = find_packages(),
 
     author = "A10 Networks",


### PR DESCRIPTION
When creating a service group, you can either specify a `health-check` or `health-check-disable` field.  You can't use both.  Setting health-check to None resulted in the property not being set in the JSON structure.  This code ensures this gets in to the JSON structure and fixes all tests in neutron-lbaas EXCEPT:
test_create_pool_missing_tenant_id_for_other_tenant
test_create_pool_missing_tenant_id_for_admin

These tests fail due to partition issues that still need to be resolved.  