### PR TITLE
Fixes 'ACOSException: 1174' on multipart uploads

### DIFF
--- a/acos_client/v21/slb/aflex.py
+++ b/acos_client/v21/slb/aflex.py
@@ -20,7 +20,7 @@ class Aflex(base.BaseV21):
         m = multipart.Multipart()
         m.file(name="upload_aflex", filename=name, value=aflex)
         ct, payload = m.get()
-        kwargs.update(payload=payload, headers={'Content-Type': ct})
+        kwargs.update(payload=payload, headers={'Content-type': ct})
         return self._post(action, **kwargs)
 
     def upload(self, name, aflex, **kwargs):

--- a/acos_client/v21/slb/class_list.py
+++ b/acos_client/v21/slb/class_list.py
@@ -39,7 +39,7 @@ class ClassList(base.BaseV21):
         m = multipart.Multipart()
         m.file(name=name, filename=name, value=class_list)
         ct, payload = m.get()
-        kwargs.update(payload=payload, headers={'Content-Type': ct})
+        kwargs.update(payload=payload, headers={'Content-type': ct})
         return self._post('slb.class_list.upload', **kwargs)
 
     def _set(self, action, class_list, **kwargs):

--- a/acos_client/v21/system.py
+++ b/acos_client/v21/system.py
@@ -30,7 +30,7 @@ class System(base.BaseV21):
         m = multipart.Multipart()
         m.file(name="restore", filename=name, value=data)
         ct, payload = m.get()
-        kwargs.update(payload=buffer(payload), headers={'Content-Type': ct})
+        kwargs.update(payload=buffer(payload), headers={'Content-type': ct})
         return self._post("system.restore", **kwargs)
 
     def tech_download(self, **kwargs):


### PR DESCRIPTION
The issue:
--------------
Uploading classlists & Aflex is not working:

This code is used to reproduce the issue:
```python
from acos_client import Client, AXAPI_21
client = Client('192.168.5.xxx', AXAPI_21, 'admin', 'xxxxx', 443)
client.slb.class_list.upload('test1', 'str a a')
```

This is the HTTP POST that is being sent:
**Note that there are 2 *content-type* headers.**
```
POST /services/rest/v2.1/?format=json&method=slb.class_list.upload&session_id=xxx HTTP/1.1
Host: 192.168.5.xxx
Accept-Encoding: identity
Content-Length: 157
Content-Type: multipart/form-data; boundary=----------AaB03x
Content-type: application/json
User-Agent: ACOS-Client-AGENT-1.2.7

------------AaB03x
Content-Type: application/octet-stream
Content-Disposition: form-data; name="test1"; filename="test1"

str a a
------------AaB03x--
```

The response is:
```json
{"response": {"status": "fail", "err": {"code": 1174, "msg": "Invalid JSON document."}}}
```

The fix:
----------
The cause for the duplicate headers, is:
in [axapi_http.py](https://github.com/a10networks/acos-client/blob/0d773142c29f8262904ce8d849d7131e49a0ccd4/acos_client/v21/axapi_http.py#L154-168),  headers dictionaries are merged using `dict(d1, d2)` which will replace items in `d1` if there's an exact match to a key in `d2`.

This is a bit misleading, as HTTP headers are case insensitive.

However, I've opted to do the simplest possible fix -- ensuring all overrides of content type are written *exactly* as [the default content type header in axapi_http.py](https://github.com/a10networks/acos-client/blob/0d773142c29f8262904ce8d849d7131e49a0ccd4/acos_client/v21/axapi_http.py#L109).