### PR TITLE
added optional http timeout for v21

### DIFF
--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -57,12 +57,12 @@ VERSION_IMPORTS = {
 class Client(object):
 
     def __init__(self, host, version, username, password, port=None,
-                 protocol="https"):
+                 protocol="https", timeout=None):
         self._version = self._just_digits(version)
         if self._version not in acos_client.AXAPI_VERSIONS:
             raise acos_errors.ACOSUnsupportedVersion()
         self.http = VERSION_IMPORTS[self._version]['http'].HttpClient(
-            host, port, protocol)
+            host, port, protocol, timeout=timeout)
         self.session = VERSION_IMPORTS[self._version]['Session'](
             self, username, password)
         self.current_partition = 'shared'

--- a/acos_client/v21/axapi_http.py
+++ b/acos_client/v21/axapi_http.py
@@ -112,10 +112,11 @@ class HttpClient(object):
 
     headers = {}
 
-    def __init__(self, host, port=None, protocol="https", client=None):
+    def __init__(self, host, port=None, protocol="https", client=None, timeout=None):
         self.host = host
         self.port = port
         self.protocol = protocol
+        self.timeout = timeout
         if port is None:
             if protocol is 'http':
                 self.port = 80
@@ -124,10 +125,10 @@ class HttpClient(object):
 
     def _http(self, method, api_url, payload):
         if self.protocol == 'https':
-            http = httplib.HTTPSConnection(self.host, self.port)
+            http = httplib.HTTPSConnection(self.host, self.port, timeout=self.timeout)
             http.connect = lambda: force_tlsv1_connect(http)
         else:
-            http = httplib.HTTPConnection(self.host, self.port)
+            http = httplib.HTTPConnection(self.host, self.port, timeout=self.timeout)
 
         LOG.debug("axapi_http: url:     %s", api_url)
         LOG.debug("axapi_http: method:  %s", method)

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -50,7 +50,7 @@ class HttpClient(object):
         "User-Agent": "ACOS-Client-AGENT-%s" % acos_client.VERSION,
     }
 
-    def __init__(self, host, port=None, protocol="https"):
+    def __init__(self, host, port=None, protocol="https", timeout=None):
         if port is None:
             if protocol is 'http':
                 port = 80


### PR DESCRIPTION
Optional timeout parameter to client, because the default is too high.

I've implemented it on v21 only, because we don't use v3 so I can't really test it, but it should be trivial to add.

based on @alonbg [commit](https://github.com/alonbg/acos-client/commit/027370e47862ea64d289a6f55378fe45fb28140d)