### PR TITLE
Use requests library in api 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ docs/_build/
 Vagrantfile
 .vagrant/
 tags
+*.swp

--- a/acos_client/v21/axapi_http.py
+++ b/acos_client/v21/axapi_http.py
@@ -17,12 +17,12 @@
 import errno
 import json
 import logging
-import socket
+import requests
+import requests.exceptions
 import sys
 import time
 import urlparse
-import requests
-import requests.exceptions
+
 import responses as acos_responses
 
 import acos_client

--- a/acos_client/v21/slb/hm.py
+++ b/acos_client/v21/slb/hm.py
@@ -82,3 +82,6 @@ class HealthMonitor(base.BaseV21):
 
     def delete(self, name, **kwargs):
         self._post("slb.hm.delete", {"name": name}, **kwargs)
+
+    def all(self, **kwargs):
+        return self._get('slb.hm.getAll', **kwargs)

--- a/acos_client/v21/slb/port.py
+++ b/acos_client/v21/slb/port.py
@@ -19,24 +19,25 @@ class Port(base.BaseV21):
     TCP = 2
     UDP = 3
 
-    def _set(self, action, name, port_num, protocol, **kwargs):
+    def _set(self, action, name, port_num, protocol, status=None, **kwargs):
 
         params = {
             "name": name,
-            "port": {
+            "port": self.minimal_dict({
                 "port_num": port_num,
                 "protocol": protocol,
-            }
+                "status": status,
+            })
         }
 
         return self._post(action, params, **kwargs)
 
-    def create(self, name, port_num, protocol, **kwargs):
-        return self._set("slb.server.port.create", name, port_num, protocol,
+    def create(self, name, port_num, protocol, status=None, **kwargs):
+        return self._set("slb.server.port.create", name, port_num, protocol, status=status,
                          **kwargs)
 
-    def update(self, name, port_num, protocol, **kwargs):
-        return self._set("slb.server.port.update", name, port_num, protocol,
+    def update(self, name, port_num, protocol, status=None, **kwargs):
+        return self._set("slb.server.port.update", name, port_num, protocol, status=status,
                          **kwargs)
 
     def all_update(self, name, port_num, protocol, **kwargs):

--- a/acos_client/v21/slb/port.py
+++ b/acos_client/v21/slb/port.py
@@ -19,7 +19,7 @@ class Port(base.BaseV21):
     TCP = 2
     UDP = 3
 
-    def _set(self, action, name, port_num, protocol, status=None, **kwargs):
+    def _set(self, action, name, port_num, protocol, status=None, hm=None, **kwargs):
 
         params = {
             "name": name,
@@ -27,17 +27,18 @@ class Port(base.BaseV21):
                 "port_num": port_num,
                 "protocol": protocol,
                 "status": status,
+                "health_monitor": hm,
             })
         }
 
         return self._post(action, params, **kwargs)
 
-    def create(self, name, port_num, protocol, status=None, **kwargs):
-        return self._set("slb.server.port.create", name, port_num, protocol, status=status,
+    def create(self, name, port_num, protocol, status=None, hm=None, **kwargs):
+        return self._set("slb.server.port.create", name, port_num, protocol, status=status, hm=hm,
                          **kwargs)
 
-    def update(self, name, port_num, protocol, status=None, **kwargs):
-        return self._set("slb.server.port.update", name, port_num, protocol, status=status,
+    def update(self, name, port_num, protocol, status=None, hm=None, **kwargs):
+        return self._set("slb.server.port.update", name, port_num, protocol, status=status, hm=hm,
                          **kwargs)
 
     def all_update(self, name, port_num, protocol, **kwargs):

--- a/acos_client/v21/slb/virtual_port.py
+++ b/acos_client/v21/slb/virtual_port.py
@@ -48,34 +48,39 @@ class VirtualPort(base.BaseV21):
 
     def _set(self, action, virtual_server_name, name, protocol, port,
              service_group_name,
-             s_pers_name=None, c_pers_name=None, status=1, **kwargs):
+             s_pers_name=None, c_pers_name=None, status=1, extras={}, **kwargs):
+
+        vport_dict = {
+            "name": name,
+            "service_group": service_group_name,
+            "protocol": protocol,
+            "port": int(port),
+            "source_ip_persistence_template": s_pers_name,
+            "cookie_persistence_template": c_pers_name,
+            "status": status
+        }
+
+        vport_dict.update(extras)
+
         params = {
             "name": virtual_server_name,
-            "vport": self.minimal_dict({
-                "name": name,
-                "service_group": service_group_name,
-                "protocol": protocol,
-                "port": int(port),
-                "source_ip_persistence_template": s_pers_name,
-                "cookie_persistence_template": c_pers_name,
-                "status": status
-            })
+            "vport": self.minimal_dict(vport_dict),
         }
         self._post(action, params, **kwargs)
 
     def create(self, virtual_server_name, name, protocol, port,
                service_group_name,
-               s_pers_name=None, c_pers_name=None, status=1, **kwargs):
+               s_pers_name=None, c_pers_name=None, status=1, extras={}, **kwargs):
         self._set('slb.virtual_server.vport.create', virtual_server_name,
                   name, protocol, port, service_group_name,
-                  s_pers_name, c_pers_name, status, **kwargs)
+                  s_pers_name, c_pers_name, status, extras=extras, **kwargs)
 
     def update(self, virtual_server_name, name, protocol, port,
                service_group_name,
-               s_pers_name=None, c_pers_name=None, status=1, **kwargs):
+               s_pers_name=None, c_pers_name=None, status=1, extras={}, **kwargs):
             self._set('slb.virtual_server.vport.update', virtual_server_name,
                       name, protocol, port, service_group_name,
-                      s_pers_name, c_pers_name, status, **kwargs)
+                      s_pers_name, c_pers_name, status, extras=extras, **kwargs)
 
     def delete(self, virtual_server_name, name, protocol, port, **kwargs):
         params = {


### PR DESCRIPTION
I ran into problems when making several queries against the load balancer where the ssl handshake would hang. Using requests (which is already in use for api 3.0) solves the problem.
