### PR TITLE
Port update workaround for 4.0.3

### DIFF
--- a/acos_client/v30/responses.py
+++ b/acos_client/v30/responses.py
@@ -108,6 +108,11 @@ RESPONSE_CODES = {
             '*': ae.NotFound
         }
     },
+    1023508480: {
+        '*': {
+            '*': ae.AxapiJsonFormatError
+        }
+    },
     1023524874: {
         '*': {
             '*': ae.AxapiJsonFormatError

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -87,7 +87,7 @@ class VirtualPort(base.BaseV30):
                 port_number=port, protocol=protocol
             )
 
-	try:
+        try:
             return self._post(url, params, **kwargs)
         except ae.AxapiJsonFormatError as e:
             # Workaround for 4.0.3

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -87,7 +87,20 @@ class VirtualPort(base.BaseV30):
                 port_number=port, protocol=protocol
             )
 
-        return self._post(url, params, **kwargs)
+	try:
+            return self._post(url, params, **kwargs)
+        except ae.AxapiJsonFormatError as e:
+            # Workaround for 4.0.3
+            # Try again without the nulls
+            changed = False
+            for exclude_key in exclude_minimize:
+                if params["port"].get(exclude_key, '') is None:
+                    del params["port"][exclude_key]
+                    changed = True
+            if changed:
+                return self._post(url, params, **kwargs)
+            else:
+                raise e
 
     def create(self, virtual_server_name, name, protocol, port,
                service_group_name,


### PR DESCRIPTION
This reduces the severity of the bug in 4.0.3 from all port updates fail to port updates don't clear persistence.

 * If the port update fails due to JSON message is wrong, resubmit it without updating the persistence templates to None.