### PR TITLE
v21/30 member opers + t.py resilience

### DIFF
--- a/acos_client/tests/t.py
+++ b/acos_client/tests/t.py
@@ -409,6 +409,11 @@ def run_all(ax, partition, pmap):
     else:
         raise Nope()
 
+    print("Member get_oper")
+    oper = c.slb.service_group.member.get_oper("pfoobar", "foorbar", 80)
+    print(oper)
+
+
     c.slb.service_group.member.update("pfoobar", "foobar", 80,
                                       c.slb.DOWN)
     try:

--- a/acos_client/tests/t.py
+++ b/acos_client/tests/t.py
@@ -262,10 +262,18 @@ def run_all(ax, partition, pmap):
     print("")
     print("SG Create")
     # temp -- odd that we have to delete this vport
-    # c.slb.virtual_server.vport.delete(
-    #     "vip3", "vip3_VPORT", c.slb.virtual_server.vport.HTTP, 80)
-    # # temp -- odd that we have to delete this vport
-    # c.slb.service_group.delete("pfoobar")
+    try:
+        c.slb.virtual_server.vport.delete(
+            "vip3", "vip3_VPORT", c.slb.virtual_server.vport.HTTP, 80)
+    except acos_client.errors.NotFound:
+        print("vip3 doesn't exist, that's OK")
+
+    # temp -- odd that we have to delete this vport
+    try:
+        c.slb.service_group.delete("pfoobar")
+    except acos_client.errors.NotExist:
+        print("sg pfoobar doesn't exist, that's OK")
+
     c.slb.service_group.create("pfoobar", c.slb.service_group.TCP,
                                c.slb.service_group.ROUND_ROBIN)
     r = c.slb.service_group.get("pfoobar")
@@ -410,9 +418,8 @@ def run_all(ax, partition, pmap):
         raise Nope()
 
     print("Member get_oper")
-    oper = c.slb.service_group.member.get_oper("pfoobar", "foorbar", 80)
+    oper = c.slb.service_group.member.get_oper("pfoobar", "foobar", 80)
     print(oper)
-
 
     c.slb.service_group.member.update("pfoobar", "foobar", 80,
                                       c.slb.DOWN)
@@ -504,7 +511,10 @@ def run_all(ax, partition, pmap):
     sflow_ip = "10.48.9.50"
     sflow_port = 6343
 
-    c.sflow.setting.create(60, True, 60, 60)
+    try:
+        c.sflow.setting.create(60, True, 60, 60)
+    except NotImplementedError:
+        print("sflow not implemented in 2.1")
 
     try:
         c.sflow.collector.ip.create(sflow_ip, sflow_port)
@@ -521,50 +531,71 @@ def run_all(ax, partition, pmap):
     print("=============================================================")
     print("")
     print("License Manager")
-    print("... Create")
     lm_host = {"ip": "10.200.0.1", "port": 443}
-    c.license_manager.create([lm_host])
-    print("... Get")
-    c.license_manager.get()
-    print("...Update")
-    lm_host["ip"] = "10.200.0.2"
-    c.license_manager.update([lm_host])
-
-    print("=============================================================")
-    print("")
-    print("slb.common")
-    print("dsr_health_check")
-    c.slb.common.create(dsr_health_check_enable=1)
-
-    print("... Get updated")
-    lm_u = c.license_manager.get()
-    print("Updated license: {0}".format(lm_u))
-
-    print("=============================================================")
-    print("")
-    print("Interface Tests")
-    print("=============================================================")
-    eth_ifs = c.interface.ethernet.get()
-    mgmt_if = c.interface.management.get()
-    print("Ethernet Interfaces:\r\n{0}".format(eth_ifs))
-    print("Manage Interfaces:\r\n{0}".format(mgmt_if))
-    eth1 = c.interface.ethernet.get(1)
-    print("Ethernet Interface 1:\r\n{0}".format(eth1))
-    print("Updating interface 1 with DHCP...")
-    c.interface.ethernet.update(1, enable=False)
-    print("Updating interface 1 with fake IP...")
     try:
-        c.interface.ethernet.update(1, dhcp=False, ip_address="",
-                                    ip_netmask="", enable=False)
-        c.interface.ethernet.update(1, dhcp=False, ip_address="10.200.0.1",
-                                    ip_netmask="255.255.255.0", enable=True)
-    except acos_client.errors.ACOSException:
-        print("Could not update interface")
+        print("... Create")
+        c.license_manager.create([lm_host])
+    except NotImplementedError:
 
-    c.interface.ethernet.get(1)
+        print("License Manager not implemented in %s " % ARGS.axapi_version)
 
-    eth1_dhcp = c.interface.ethernet.get(1)
-    print("Updated interface 1 DHCP: {0}".format(eth1_dhcp))
+    try:
+        print("... Get")
+        c.license_manager.get()
+    except NotImplementedError:
+        print("License Manager not implemented in %s " % ARGS.axapi_version)
+
+    lm_host["ip"] = "10.200.0.2"
+    try:
+        print("... Update")
+        c.license_manager.update([lm_host])
+    except NotImplementedError:
+        print("License Manager not implemented in %s " % ARGS.axapi_version)
+
+    if float(ARGS.axapi_version) >= 3.0:
+        print("=============================================================")
+        print("")
+        print("slb.common")
+        print("dsr_health_check")
+        try:
+            c.slb.common.create(dsr_health_check_enable=1)
+        except NotImplementedError:
+            print("DSR Health Check not implemented in %s" % ARGS.axapi_version)
+        print("... Get updated")
+
+    if float(ARGS.axapi_version) >= 3.0:
+        print("=============================================================")
+        print("")
+        print("Interface Tests")
+        print("=============================================================")
+        try:
+            eth_ifs = c.interface.ethernet.get()
+        except NotImplementedError:
+            print("Interface Manipulation is implemented in AXAPI 2.1 but not acos-client")
+        try:
+            mgmt_if = c.interface.management.get()
+        except NotImplementedError:
+            print("Interface Manipulation is implemented in AXAPI 2.1 but not acos-client")
+
+        print("Ethernet Interfaces:\r\n{0}".format(eth_ifs))
+        print("Manage Interfaces:\r\n{0}".format(mgmt_if))
+        eth1 = c.interface.ethernet.get(1)
+        print("Ethernet Interface 1:\r\n{0}".format(eth1))
+        print("Updating interface 1 with DHCP...")
+        c.interface.ethernet.update(1, enable=False)
+        print("Updating interface 1 with fake IP...")
+        try:
+            c.interface.ethernet.update(1, dhcp=False, ip_address="",
+                                        ip_netmask="", enable=False)
+            c.interface.ethernet.update(1, dhcp=False, ip_address="10.200.0.1",
+                                        ip_netmask="255.255.255.0", enable=True)
+        except acos_client.errors.ACOSException:
+            print("Could not update interface")
+
+        c.interface.ethernet.get(1)
+
+        eth1_dhcp = c.interface.ethernet.get(1)
+        print("Updated interface 1 DHCP: {0}".format(eth1_dhcp))
 
     print("=============================================================")
     print("")
@@ -578,6 +609,10 @@ def run_all(ax, partition, pmap):
             pass
 
     c.session.close()
+
+    print("=============================================================")
+    print("t.py completed successfully!")
+    print("=============================================================")
 
 
 def main():

--- a/acos_client/v21/slb/member.py
+++ b/acos_client/v21/slb/member.py
@@ -42,3 +42,8 @@ class Member(base.BaseV21):
     def delete(self, service_group_name, server_name, server_port, **kwargs):
         self._write("slb.service_group.member.delete", service_group_name,
                     server_name, int(server_port), **kwargs)
+
+    def get_oper(self, service_group_name, server_name, server_port, **kwargs):
+        return self._post("slb.service_group.member.oper", service_group_name,
+                          server_name, int(server_port), **kwargs)
+

--- a/acos_client/v21/slb/member.py
+++ b/acos_client/v21/slb/member.py
@@ -44,6 +44,7 @@ class Member(base.BaseV21):
                     server_name, int(server_port), **kwargs)
 
     def get_oper(self, service_group_name, server_name, server_port, **kwargs):
-        return self._post("slb.service_group.member.oper", service_group_name,
-                          server_name, int(server_port), **kwargs)
-
+        sg_stats = self._post("slb.service_group.fetchStatistics",
+                              {"name": service_group_name}, **kwargs)
+        members_stats = sg_stats["service_group_stat"]["member_stat_list"]
+        member_stats = filter(lambda x: x["name"] == server_name)

--- a/acos_client/v21/slb/member.py
+++ b/acos_client/v21/slb/member.py
@@ -47,4 +47,5 @@ class Member(base.BaseV21):
         sg_stats = self._post("slb.service_group.fetchStatistics",
                               {"name": service_group_name}, **kwargs)
         members_stats = sg_stats["service_group_stat"]["member_stat_list"]
-        member_stats = filter(lambda x: x["name"] == server_name)
+        member_stats = filter(lambda x: x.get("server") == server_name, members_stats)
+        return member_stats

--- a/acos_client/v30/slb/member.py
+++ b/acos_client/v30/slb/member.py
@@ -32,7 +32,7 @@ class Member(base.BaseV30):
         )
 
         return self._get(url, **kwargs)
-        
+
     def get_oper(self, service_group_name, server_name, server_port, **kwargs):
         url = self.url_base_tmpl.format(gname=service_group_name)
         url += self.url_mbr_tmpl.format(

--- a/acos_client/v30/slb/member.py
+++ b/acos_client/v30/slb/member.py
@@ -32,6 +32,14 @@ class Member(base.BaseV30):
         )
 
         return self._get(url, **kwargs)
+        
+    def get_oper(self, service_group_name, server_name, server_port, **kwargs):
+        url = self.url_base_tmpl.format(gname=service_group_name)
+        url += self.url_mbr_tmpl.format(
+            name=server_name,
+            port=server_port
+        )
+        return self._get(url+'oper', **kwargs)
 
     def _write(self,
                service_group_name,

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -51,10 +51,8 @@ class Server(base.BaseV30):
             }
         }
 
-        try:
-            self.get(name, **kwargs)
-        except acos_errors.NotFound:
-            raise acos_errors.NotFound()
+        self.get(name, **kwargs)
+
         return self._post(self.url_prefix + name, params, **kwargs)
 
     def delete(self, name):

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -51,7 +51,10 @@ class Server(base.BaseV30):
             }
         }
 
-        self.get(name, **kwargs)
+        try:
+            self.get(name, **kwargs)
+        except acos_errors.NotFound:
+            raise acos_errors.NotFound()
         return self._post(self.url_prefix + name, params, **kwargs)
 
     def delete(self, name):


### PR DESCRIPTION
Added "get_opers" methods to members
t.py enhancements
* tests member "get_opers" calls
* wrapped "dirty" (t.py isn't always run against freshly spawned vThunders) logic in try/catch blocks
* wrapped version specific logic in conditional blocks
* Catches NotImplementedError thrown by v2.1 clients that don't yet implement functionality that either isn't implemented in AXAPI or we don't want to have it in acos-client v3.0 (encourage people to use new SDK, it's nicer)