### PR TITLE
Added oper stats

### DIFF
--- a/acos_client/tests/t.py
+++ b/acos_client/tests/t.py
@@ -328,6 +328,12 @@ def run_all(ax, partition, pmap):
         c.slb.virtual_server.stats("vfoobar")
     except Exception:
         pass
+    try:
+        oper = c.slb.virtual_server.oper("vfoobar")
+        print("OPERATIONAL STATS (VIRTUAL SERVER):")
+        print(oper)
+    except Exception as ex:
+        print(ex)
     c.slb.virtual_server.delete("vfoobar")
     c.slb.virtual_server.delete("vfoobar")
     try:
@@ -416,6 +422,12 @@ def run_all(ax, partition, pmap):
         print("got already exists error, good")
     else:
         raise Nope()
+    try:
+        oper = c.slb.service_group.oper("vfoobar")
+        print("OPERATIONAL STATS (SERVICE GROUP):")
+        print(oper)
+    except Exception:
+        pass
 
     print("Member get_oper")
     oper = c.slb.service_group.member.get_oper("pfoobar", "foobar", 80)

--- a/acos_client/tests/unit/v30/test_service_group.py
+++ b/acos_client/tests/unit/v30/test_service_group.py
@@ -64,3 +64,14 @@ class TestServiceGroup(unittest.TestCase):
         expected_url = "/axapi/v3/slb/service-group/{0}/stats".format(sgname)
         self.assertEqual(method, "GET")
         self.assertEqual(expected_url, url)
+
+    def test_oper(self):
+        client = mock.MagicMock()
+        sg = service_group.ServiceGroup(client)
+        sgname = "fake-pool"
+        sg.oper(sgname)
+
+        ((method, url, params, header), kwargs) = client.http.request.call_args
+        expected_url = "/axapi/v3/slb/service-group/{0}/oper".format(sgname)
+        self.assertEqual(method, "GET")
+        self.assertEqual(expected_url, url)

--- a/acos_client/tests/unit/v30/test_virtual_server.py
+++ b/acos_client/tests/unit/v30/test_virtual_server.py
@@ -45,3 +45,14 @@ class TestVirtualServer(unittest.TestCase):
         call_source = self.client.http
         expected_payload = self._build_payload(arp_disable=arp_disable)
         call_source.request.assert_called_with('POST', EXPECTED_URL, expected_payload, mock.ANY)
+
+    def test_oper(self):
+        client = mock.MagicMock()
+        vs = virtual_server.VirtualServer(client)
+        vsname = "fake-loadbalancer"
+        vs.oper(vsname)
+
+        ((method, url, params, header), kwargs) = client.http.request.call_args
+        expected_url = "/axapi/v3/slb/virtual-server/{0}/oper".format(vsname)
+        self.assertEqual(method, "GET")
+        self.assertEqual(expected_url, url)

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -109,3 +109,6 @@ class ServiceGroup(base.BaseV30):
 
     def stats(self, name, *args, **kwargs):
         return self._get(self.url_prefix + name + "/stats", **kwargs)
+
+    def oper(self, name, *args, **kwargs):
+        return self._get(self.url_prefix + name + "/oper", **kwargs)

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -68,7 +68,9 @@ class VirtualServer(base.BaseV30):
         return self._delete(self.url_prefix + name)
 
     def stats(self, name='', **kwargs):
-        # resp = self._get(self.url_prefix + name + '/stats/')
         resp = self._get(self.url_prefix + name + '/stats', **kwargs)
         return resp
-        # raise acos_errors.NotImplemented()
+
+    def oper(self, name='', **kwargs):
+        resp = self._get(self.url_prefix + name + '/oper', **kwargs)
+        return resp


### PR DESCRIPTION
Adds a method that gives the service groups and virtual servers access to the operational stats on the acos device.