### PR TITLE
Implement support for slb.service_group.fetchAllStatistics method

### DIFF
--- a/acos_client/v21/slb/service_group.py
+++ b/acos_client/v21/slb/service_group.py
@@ -79,3 +79,6 @@ class ServiceGroup(base.BaseV21):
     def stats(self, name, **kwargs):
         return self._post("slb.service_group.fetchStatistics",
                           {"name": name}, **kwargs)
+
+    def all_stats(self, **kwargs):
+        return self._get("slb.service_group.fetchAllStatistics", **kwargs)


### PR DESCRIPTION
The fetchAllStatistics method for Service Groups was not implemented. This adds it, using a similar format to that Virtual Servers. Tests on all supported Python versions passed.