### PR TITLE
Fixed to enable changing for the member status of ServiceGroup with a XAPI3.0

### DIFF
--- a/acos_client/tests/unit/v30/test_member.py
+++ b/acos_client/tests/unit/v30/test_member.py
@@ -1,0 +1,96 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+import unittest2 as unittest
+
+from acos_client import errors as acos_errors
+from acos_client.v30.slb import member
+
+
+class TestMember(unittest.TestCase):
+    def setUp(self):
+        self.client = mock.MagicMock()
+        self.member = member.Member(self.client)
+        self.member._get = mock.MagicMock(side_effect=acos_errors.NotFound)
+
+        # common test parameter(s) throughout all test-cases
+        self._sg_name = 'fake-sg'
+
+    def test_create_enable_member(self):
+        expected = {
+            'member': {
+                'name': 'fake-srever',
+                'port': 80,
+                'member-stats-data-disable': self.member.STATUS_ENABLE,
+                'member-state': 'enable',
+            }
+        }
+        self.member.create(self._sg_name, 'fake-srever', 80)
+
+        ((method, url, params, header), kwargs) = self.client.http.request.call_args
+
+        self.assertEqual(url, '/axapi/v3/slb/service-group/%s/member/' % (self._sg_name))
+        self.assertEqual(params, expected)
+
+    def test_create_disable_member(self):
+        expected = {
+            'member': {
+                'name': 'fake-srever',
+                'port': 80,
+                'member-stats-data-disable': self.member.STATUS_DISABLE,
+                'member-state': 'disable',
+            }
+        }
+        self.member.create(self._sg_name, 'fake-srever', 80, self.member.STATUS_DISABLE, False)
+
+        ((method, url, params, header), kwargs) = self.client.http.request.call_args
+
+        self.assertEqual(params, expected)
+
+    def test_update_enable_member(self):
+        expected = {
+            'member': {
+                'name': 'fake-srever',
+                'port': 443,
+                'member-stats-data-disable': self.member.STATUS_ENABLE,
+                'member-state': 'enable',
+            }
+        }
+        self.member.update(self._sg_name, 'fake-srever', 443)
+
+        ((method, url, params, header), kwargs) = self.client.http.request.call_args
+
+        self.assertEqual(url, '/axapi/v3/slb/service-group/%s/member/%s+%s/' % 
+                              (self._sg_name,
+                               expected['member']['name'],
+                               expected['member']['port']))
+        self.assertEqual(params, expected)
+
+    def test_update_disable_member(self):
+        expected = {
+            'member': {
+                'name': 'fake-srever',
+                'port': 443,
+                'member-stats-data-disable': self.member.STATUS_DISABLE,
+                'member-state': 'disable',
+            }
+        }
+        self.member.update(self._sg_name, 'fake-srever', 443, self.member.STATUS_DISABLE, False)
+
+        ((method, url, params, header), kwargs) = self.client.http.request.call_args
+
+        self.assertEqual(url, '/axapi/v3/slb/service-group/%s/member/%s+%s/' % 
+                              (self._sg_name,
+                               expected['member']['name'],
+                               expected['member']['port']))
+        self.assertEqual(params, expected)

--- a/acos_client/v30/slb/member.py
+++ b/acos_client/v30/slb/member.py
@@ -46,6 +46,7 @@ class Member(base.BaseV30):
                server_name,
                server_port,
                status=STATUS_ENABLE,
+               member_state=True,
                update=False, **kwargs):
 
         url = self.url_base_tmpl.format(gname=service_group_name)
@@ -61,6 +62,7 @@ class Member(base.BaseV30):
                 "port": int(server_port),
                 # flip status code, becuase it's a disable flag in v30
                 "member-stats-data-disable": status,
+                "member-state": member_state and 'enable' or 'disable',
             })
         }
 
@@ -70,7 +72,8 @@ class Member(base.BaseV30):
                service_group_name,
                server_name,
                server_port,
-               status=STATUS_ENABLE, **kwargs):
+               status=STATUS_ENABLE,
+               member_state=True, **kwargs):
         try:
             self.get(service_group_name, server_name, server_port)
         except acos_errors.NotFound:
@@ -79,15 +82,16 @@ class Member(base.BaseV30):
             raise acos_errors.Exists()
 
         self._write(service_group_name,
-                    server_name, server_port, status, **kwargs)
+                    server_name, server_port, status, member_state, **kwargs)
 
     def update(self,
                service_group_name,
                server_name,
                server_port,
-               status=STATUS_ENABLE, **kwargs):
+               status=STATUS_ENABLE,
+               member_state=True, **kwargs):
         self._write(service_group_name,
-                    server_name, server_port, status, update=True, **kwargs)
+                    server_name, server_port, status, member_state, update=True, **kwargs)
 
     def delete(self, service_group_name, server_name, server_port):
         url = self.url_base_tmpl.format(gname=service_group_name)


### PR DESCRIPTION
Thank you very much for providing this great software. I use this library for operating our vThunder appliance.

BTW, I found a following problem.
In the current implementation, we can't manipulate the member status of the ServiceGroup because of lack of the `member-state` parameter to the member method of the aXAPI ver.3.0.
We can only add or update 'enabled' member.

In this patch, the `member_state` argument is added to specify the member status ('enable' or 'disable').
We can select member's status by this patch.