### PR TITLE
Added the implementation to operate port on a real-server in SLB using the aXAPI3.0

### DIFF
--- a/acos_client/tests/unit/v30/test_port.py
+++ b/acos_client/tests/unit/v30/test_port.py
@@ -1,0 +1,77 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+import unittest2 as unittest
+
+from acos_client.v30.slb import port
+
+
+class TestPort(unittest.TestCase):
+    def setUp(self):
+        self.client = mock.MagicMock()
+        self.port = port.Port(self.client)
+
+        # common test parameter(s) throughout all test-cases
+        self._server_name = 'test_server'
+
+    def test_create_port(self):
+        expected = {
+            'port': {
+                "conn-resume": None,
+                "conn-limit": 8000000,
+                "stats-data-action": "stats-data-enable",
+                "weight": 1,
+                "port-number": 80,
+                "range": 0,
+                "action": "enable",
+                "protocol": 'tcp'
+            }
+        }
+        self.port.create('test_server', 80, 'tcp')
+
+        ((method, url, params, header), kwargs) = self.client.http.request.call_args
+
+        self.assertEqual(method, 'POST')
+        self.assertEqual(url, '/axapi/v3/slb/server/%s/port/' % self._server_name)
+        self.assertEqual(params, expected)
+
+    def test_update_port(self):
+        expected = {
+            'port': {
+                "conn-resume": None,
+                "conn-limit": 12345,
+                "stats-data-action": "stats-data-enable",
+                "weight": 2,
+                "port-number": 80,
+                "range": 0,
+                "action": "enable",
+                "protocol": 'tcp'
+            }
+        }
+        self.port.update('test_server', 80, 'tcp', conn_limit=12345, weight=2)
+
+        ((method, url, params, header), kwargs) = self.client.http.request.call_args
+
+        self.assertEqual(method, 'PUT')
+        self.assertEqual(url, '/axapi/v3/slb/server/%s/port/%s+%s/' %
+                              (self._server_name, 80, 'tcp'))
+        self.assertEqual(params, expected)
+
+    def test_delete_port(self):
+        self.port.delete('test_server', 80, 'tcp')
+
+        ((method, url, params, header), kwargs) = self.client.http.request.call_args
+
+        self.assertEqual(method, 'DELETE')
+        self.assertEqual(url, '/axapi/v3/slb/server/%s/port/%s+%s/' %
+                              (self._server_name, 80, 'tcp'))

--- a/acos_client/v30/slb/port.py
+++ b/acos_client/v30/slb/port.py
@@ -1,0 +1,55 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import acos_client.v30.base as base
+
+
+class Port(base.BaseV30):
+
+    url_base_tmpl = "/slb/server/{server}/port/"
+    url_port_tmpl = "{port}+{protocol}/"
+
+    def create(self, server_name, port, protocol, **kwargs):
+        return self._set(server_name, port, protocol, **kwargs)
+
+    def update(self, server_name, port, protocol, **kwargs):
+        return self._set(server_name, port, protocol, update=True, **kwargs)
+
+    def delete(self, server_name, port, protocol, **kwargs):
+        url = (self.url_base_tmpl + self.url_port_tmpl).format(server=server_name,
+                                                               port=port,
+                                                               protocol=protocol)
+
+        return self._delete(url)
+
+    def _set(self, server_name, port, protocol, update=False, **kwargs):
+        url = self.url_base_tmpl.format(server=server_name)
+
+        params = {
+            "port": {
+                "conn-resume": kwargs.get("conn_resume", None),
+                "conn-limit": kwargs.get("conn_limit", 8000000),
+                "stats-data-action": kwargs.get("stats_data_action", "stats-data-enable"),
+                "weight": kwargs.get("weight", 1),
+                "port-number": port,
+                "range": kwargs.get("range", 0),
+                "action": kwargs.get("action", "enable"),
+                "protocol": protocol
+            }
+        }
+
+        if update:
+            url += self.url_port_tmpl.format(port=port, protocol=protocol)
+
+            return self._put(url, params, **kwargs)
+        else:
+            return self._post(url, params, **kwargs)

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -15,6 +15,8 @@
 import acos_client.errors as acos_errors
 import acos_client.v30.base as base
 
+from port import Port
+
 
 class Server(base.BaseV30):
 
@@ -57,3 +59,7 @@ class Server(base.BaseV30):
 
     def delete(self, name):
         return self._delete(self.url_prefix + name)
+
+    @property
+    def port(self):
+        return Port(self.client)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "acos-client",
-    version = "1.4.1",
+    version = "1.4.0",
     packages = find_packages(),
 
     author = "A10 Networks",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "acos-client",
-    version = "1.4.0",
+    version = "1.4.1",
     packages = find_packages(),
 
     author = "A10 Networks",


### PR DESCRIPTION
Previously, there is no way in this library to operate `Port` on a `Server` in the aXAPI3.0.
And the implementation to do it is added in this patch.

Thank you.