### PR TITLE
Change to using absolute imports

### DIFF
--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -11,42 +11,44 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import logging
 import socket
 
 import acos_client
 
-import errors as acos_errors
-import v21.axapi_http
-from v21.dns import DNS as v21_DNS
-from v21.ha import HA as v21_HA
-from v21.interface import Interface as v21_Interface
-from v21.license_manager import LicenseManager as v21_LicenseManager
-from v21.nat import Nat as v21_Nat
-from v21.network import Network as v21_Network
-from v21.session import Session as v21_Session
-from v21.sflow import SFlow as v21_SFlow
-from v21.slb import SLB as v21_SLB
-from v21.system import System as v21_System
+from acos_client import errors as acos_errors
+from acos_client.v21 import axapi_http as v21_http
+from acos_client.v21.dns import DNS as v21_DNS
+from acos_client.v21.ha import HA as v21_HA
+from acos_client.v21.interface import Interface as v21_Interface
+from acos_client.v21.license_manager import LicenseManager as v21_LicenseManager
+from acos_client.v21.nat import Nat as v21_Nat
+from acos_client.v21.network import Network as v21_Network
+from acos_client.v21.session import Session as v21_Session
+from acos_client.v21.sflow import SFlow as v21_SFlow
+from acos_client.v21.slb import SLB as v21_SLB
+from acos_client.v21.system import System as v21_System
 
-import v30.axapi_http
-from v30.dns import DNS as v30_DNS
-from v30.file import File as v30_File
-from v30.ha import HA as v30_HA
-from v30.interface import Interface as v30_Interface
-from v30.license_manager import LicenseManager as v30_LicenseManager
-from v30.nat import Nat as v30_Nat
-from v30.network import Network as v30_Network
-from v30.session import Session as v30_Session
-from v30.sflow import SFlow as v30_SFlow
-from v30.slb import SLB as v30_SLB
-from v30.system import System as v30_System
+from acos_client.v30 import axapi_http as v30_http
+from acos_client.v30.dns import DNS as v30_DNS
+from acos_client.v30.file import File as v30_File
+from acos_client.v30.ha import HA as v30_HA
+from acos_client.v30.interface import Interface as v30_Interface
+from acos_client.v30.license_manager import LicenseManager as v30_LicenseManager
+from acos_client.v30.nat import Nat as v30_Nat
+from acos_client.v30.network import Network as v30_Network
+from acos_client.v30.session import Session as v30_Session
+from acos_client.v30.sflow import SFlow as v30_SFlow
+from acos_client.v30.slb import SLB as v30_SLB
+from acos_client.v30.system import System as v30_System
+
 
 VERSION_IMPORTS = {
     '21': {
         'DNS': v21_DNS,
-        'http': v21.axapi_http,
+        'http': v21_http,
         'HA': v21_HA,
         'Interface': v21_Interface,
         'LicenseManager': v21_LicenseManager,
@@ -59,7 +61,7 @@ VERSION_IMPORTS = {
     },
     '30': {
         'DNS': v30_DNS,
-        'http': v30.axapi_http,
+        'http': v30_http,
         'Interface': v30_Interface,
         'HA': v30_HA,
         'LicenseManager': v30_LicenseManager,

--- a/acos_client/hash.py
+++ b/acos_client/hash.py
@@ -11,6 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import hash_ring
 

--- a/acos_client/multipart.py
+++ b/acos_client/multipart.py
@@ -23,6 +23,7 @@
 
 # Kind regards,
 # Stacy
+from __future__ import absolute_import, unicode_literals
 
 import mimetypes
 

--- a/acos_client/v21/action.py
+++ b/acos_client/v21/action.py
@@ -11,12 +11,12 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import time
 
-import acos_client.errors as acos_errors
-
-import base
+from acos_client import errors as acos_errors
+from acos_client.v21 import base
 
 
 class Action(base.BaseV21):

--- a/acos_client/v21/admin.py
+++ b/acos_client/v21/admin.py
@@ -9,8 +9,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v21 import base
 
 
 class Admin(base.BaseV21):

--- a/acos_client/v21/axapi_http.py
+++ b/acos_client/v21/axapi_http.py
@@ -13,6 +13,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import errno
 import httplib
@@ -24,10 +25,9 @@ import sys
 import time
 import urlparse
 
-import responses as acos_responses
-
 import acos_client
 from acos_client import logutils
+from acos_client.v21 import responses as acos_responses
 
 LOG = logging.getLogger(__name__)
 
@@ -205,7 +205,7 @@ class HttpClient(object):
                 break
 
         if last_e is not None:
-            raise e
+            raise last_e
 
         LOG.debug("axapi_http: data = %s", logutils.clean(data))
 

--- a/acos_client/v21/base.py
+++ b/acos_client/v21/base.py
@@ -11,10 +11,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import time
 
-import acos_client.errors as acos_errors
+from acos_client import errors as acos_errors
 
 
 class BaseV21(object):

--- a/acos_client/v21/config_file.py
+++ b/acos_client/v21/config_file.py
@@ -9,8 +9,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v21 import base
 
 
 class ConfigFile(base.BaseV21):

--- a/acos_client/v21/device_info.py
+++ b/acos_client/v21/device_info.py
@@ -9,8 +9,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v21 import base
 
 
 class DeviceInfo(base.BaseV21):

--- a/acos_client/v21/dns.py
+++ b/acos_client/v21/dns.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v21 import base
 
 
 class DNS(base.BaseV21):

--- a/acos_client/v21/ha.py
+++ b/acos_client/v21/ha.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v21 import base
 
 
 class HA(base.BaseV21):

--- a/acos_client/v21/interface.py
+++ b/acos_client/v21/interface.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v21 import base
 
 
 class Interface(base.BaseV21):

--- a/acos_client/v21/license_manager.py
+++ b/acos_client/v21/license_manager.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v21 import base
 
 
 class LicenseManager(base.BaseV21):

--- a/acos_client/v21/log.py
+++ b/acos_client/v21/log.py
@@ -9,8 +9,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v21 import base
 
 
 class Log(base.BaseV21):

--- a/acos_client/v21/nat.py
+++ b/acos_client/v21/nat.py
@@ -9,8 +9,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v21 import base
 
 
 class Nat(base.BaseV21):

--- a/acos_client/v21/network.py
+++ b/acos_client/v21/network.py
@@ -9,8 +9,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v21 import base
 
 
 class Network(base.BaseV21):

--- a/acos_client/v21/partition.py
+++ b/acos_client/v21/partition.py
@@ -11,10 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-
-import base
+from acos_client import errors as acos_errors
+from acos_client.v21 import base
 
 
 class Partition(base.BaseV21):

--- a/acos_client/v21/responses.py
+++ b/acos_client/v21/responses.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as ae
+from acos_client import errors as ae
 
 
 RESPONSE_CODES = {

--- a/acos_client/v21/session.py
+++ b/acos_client/v21/session.py
@@ -12,7 +12,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import acos_client.errors as acos_errors
+from __future__ import absolute_import, unicode_literals
+
+from acos_client import errors as acos_errors
 
 
 class Session(object):

--- a/acos_client/v21/sflow.py
+++ b/acos_client/v21/sflow.py
@@ -11,7 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
+from __future__ import absolute_import, unicode_literals
 
 from acos_client.v30 import base
 

--- a/acos_client/v21/slb/aflex.py
+++ b/acos_client/v21/slb/aflex.py
@@ -9,9 +9,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 from acos_client import multipart
-import acos_client.v21.base as base
+from acos_client.v21 import base
 
 
 class Aflex(base.BaseV21):

--- a/acos_client/v21/slb/class_list.py
+++ b/acos_client/v21/slb/class_list.py
@@ -9,12 +9,13 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import json
 import re
 
 from acos_client import multipart
-import acos_client.v21.base as base
+from acos_client.v21 import base
 
 
 class ClassList(base.BaseV21):

--- a/acos_client/v21/slb/common.py
+++ b/acos_client/v21/slb/common.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v30.base as base
+from acos_client.v30 import base
 
 
 class SLBCommon(base.BaseV21):

--- a/acos_client/v21/slb/hm.py
+++ b/acos_client/v21/slb/hm.py
@@ -11,9 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v21.base as base
+from acos_client import errors as acos_errors
+from acos_client.v21 import base
 
 
 class HealthMonitor(base.BaseV21):

--- a/acos_client/v21/slb/member.py
+++ b/acos_client/v21/slb/member.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v21.base as base
+from acos_client.v21 import base
 
 
 class Member(base.BaseV21):

--- a/acos_client/v21/slb/port.py
+++ b/acos_client/v21/slb/port.py
@@ -9,8 +9,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v21.base as base
+from acos_client.v21 import base
 
 
 class Port(base.BaseV21):

--- a/acos_client/v21/slb/server.py
+++ b/acos_client/v21/slb/server.py
@@ -11,10 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v21.base as base
-
-from port import Port
+from acos_client.v21 import base
+from acos_client.v21.slb.port import Port
 
 
 class Server(base.BaseV21):

--- a/acos_client/v21/slb/service_group.py
+++ b/acos_client/v21/slb/service_group.py
@@ -11,10 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v21.base as base
-
-from member import Member
+from acos_client.v21 import base
+from acos_client.v21.slb.member import Member
 
 
 class ServiceGroup(base.BaseV21):

--- a/acos_client/v21/slb/template/persistence.py
+++ b/acos_client/v21/slb/template/persistence.py
@@ -11,9 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v21.base as base
+from acos_client import errors as acos_errors
+from acos_client.v21 import base
 
 
 class BasePersistence(base.BaseV21):

--- a/acos_client/v21/slb/template/template_ssl.py
+++ b/acos_client/v21/slb/template/template_ssl.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v21.base as base
+from acos_client.v21 import base
 
 
 class BaseSSL(base.BaseV21):

--- a/acos_client/v21/slb/virtual_port.py
+++ b/acos_client/v21/slb/virtual_port.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v21.base as base
+from acos_client.v21 import base
 
 
 class VirtualPort(base.BaseV21):

--- a/acos_client/v21/slb/virtual_server.py
+++ b/acos_client/v21/slb/virtual_server.py
@@ -11,10 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v21.base as base
-
-from virtual_port import VirtualPort
+from acos_client.v21 import base
+from acos_client.v21.slb.virtual_port import VirtualPort
 
 
 class VirtualServer(base.BaseV21):

--- a/acos_client/v21/slb/virtual_service.py
+++ b/acos_client/v21/slb/virtual_service.py
@@ -9,8 +9,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v21.base as base
+from acos_client.v21 import base
 
 
 class VirtualService(base.BaseV21):

--- a/acos_client/v21/system.py
+++ b/acos_client/v21/system.py
@@ -11,15 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 from acos_client import multipart
-from action import Action
-from admin import Admin
-import base
-from config_file import ConfigFile
-from device_info import DeviceInfo
-from log import Log
-from partition import Partition
+from acos_client.v21 import base
+from acos_client.v21.action import Action
+from acos_client.v21.admin import Admin
+from acos_client.v21.config_file import ConfigFile
+from acos_client.v21.device_info import DeviceInfo
+from acos_client.v21.log import Log
+from acos_client.v21.partition import Partition
 
 
 class System(base.BaseV21):

--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -11,10 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as ae
-
-import base
+from acos_client import errors as ae
+from acos_client.v30 import base
 
 
 class Action(base.BaseV30):

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -11,29 +11,20 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-
-# TODO(mdurrant) - Organize these imports
 import errno
 import json
 import logging
 import socket
-import sys
 import time
 
 import requests
 
-
-if sys.version_info >= (3, 0):
-    import http.client as http_client
-else:
-    # Python 2
-    import httplib as http_client
-
-import responses as acos_responses
-
 import acos_client
 from acos_client import logutils
+from acos_client.v30 import responses as acos_responses
+
 
 LOG = logging.getLogger(__name__)
 

--- a/acos_client/v30/base.py
+++ b/acos_client/v30/base.py
@@ -11,10 +11,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import time
 
-import acos_client.errors as ae
+from acos_client import errors as ae
 
 
 class BaseV30(object):

--- a/acos_client/v30/dns.py
+++ b/acos_client/v30/dns.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v30.base as base
+from acos_client.v30 import base
 
 
 class DNS(base.BaseV30):

--- a/acos_client/v30/file/ssl_cert.py
+++ b/acos_client/v30/file/ssl_cert.py
@@ -11,9 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v30.base as base
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
 
 
 class SSLCert(base.BaseV30):

--- a/acos_client/v30/file/ssl_key.py
+++ b/acos_client/v30/file/ssl_key.py
@@ -11,9 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v30.base as base
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
 
 
 class SSLKey(base.BaseV30):

--- a/acos_client/v30/ha.py
+++ b/acos_client/v30/ha.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v30 import base
 
 
 class HA(base.BaseV30):

--- a/acos_client/v30/interface.py
+++ b/acos_client/v30/interface.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v30 import base
 
 
 class Interface(base.BaseV30):

--- a/acos_client/v30/license_manager.py
+++ b/acos_client/v30/license_manager.py
@@ -11,12 +11,12 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import time
 
-import acos_client.errors as acos_errors
-
-import base
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
 
 INTERVAL_MONTHLY = 1
 INTERVAL_DAILY = 2

--- a/acos_client/v30/nat.py
+++ b/acos_client/v30/nat.py
@@ -11,9 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v30.base as base
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
 
 
 class Nat(base.BaseV30):

--- a/acos_client/v30/network.py
+++ b/acos_client/v30/network.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import base
+from acos_client.v30 import base
 
 
 class Network(base.BaseV30):

--- a/acos_client/v30/partition.py
+++ b/acos_client/v30/partition.py
@@ -11,13 +11,13 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import random
 import time
 
-import acos_client.errors as acos_errors
-
-import base
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
 
 
 class Partition(base.BaseV30):

--- a/acos_client/v30/responses.py
+++ b/acos_client/v30/responses.py
@@ -11,10 +11,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
 import re
 
-import acos_client.errors as ae
+from acos_client import errors as ae
 
 RESPONSE_CODES = {
     33619969: {

--- a/acos_client/v30/sflow.py
+++ b/acos_client/v30/sflow.py
@@ -11,7 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
+from __future__ import absolute_import, unicode_literals
 
 from acos_client import errors as acos_errors
 from acos_client.v30 import base

--- a/acos_client/v30/slb/common.py
+++ b/acos_client/v30/slb/common.py
@@ -11,8 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v30.base as base
+from acos_client.v30 import base
 
 
 class SLBCommon(base.BaseV30):

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -11,9 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v30.base as base
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
 
 
 class HealthMonitor(base.BaseV30):

--- a/acos_client/v30/slb/member.py
+++ b/acos_client/v30/slb/member.py
@@ -11,9 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v30.base as base
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
 
 
 class Member(base.BaseV30):

--- a/acos_client/v30/slb/port.py
+++ b/acos_client/v30/slb/port.py
@@ -9,8 +9,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.v30.base as base
+from acos_client.v30 import base
 
 
 class Port(base.BaseV30):

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -11,11 +11,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v30.base as base
-
-from port import Port
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
+from acos_client.v30.slb.port import Port
 
 
 class Server(base.BaseV30):

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -11,11 +11,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v30.base as base
-
-from member import Member
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
+from acos_client.v30.slb.member import Member
 
 
 class ServiceGroup(base.BaseV30):

--- a/acos_client/v30/slb/template/persistence.py
+++ b/acos_client/v30/slb/template/persistence.py
@@ -11,9 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v30.base as base
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
 
 
 class BasePersistence(base.BaseV30):

--- a/acos_client/v30/slb/template/ssl.py
+++ b/acos_client/v30/slb/template/ssl.py
@@ -11,9 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v30.base as base
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
 
 
 class BaseSSL(base.BaseV30):

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -11,9 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as ae
-import acos_client.v30.base as base
+from acos_client import errors as ae
+from acos_client.v30 import base
 
 
 class VirtualPort(base.BaseV30):

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -11,11 +11,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-import acos_client.errors as acos_errors
-import acos_client.v30.base as base
-
-from virtual_port import VirtualPort
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
+from acos_client.v30.slb.virtual_port import VirtualPort
 
 
 class VirtualServer(base.BaseV30):

--- a/acos_client/v30/system.py
+++ b/acos_client/v30/system.py
@@ -11,10 +11,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import, unicode_literals
 
-from action import Action
-import base
-from partition import Partition
+from acos_client.v30 import base
+from acos_client.v30.action import Action
+from acos_client.v30.partition import Partition
 
 
 class System(base.BaseV30):


### PR DESCRIPTION
In beginning the efforts for #170, the first big problem I ran into was the use of relative imports. In Python 3, the style of relative imports used by this library were no longer working; none of the import statements were able to locate the referred modules.

This change uplifts all of the import statements so that they will work across all support Python versions.

I also did a little bit of cleanup of some of the imports, for consistency sake.