### PR TITLE
Add support for Python3 versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.python-version
 
 # Installer logs
 pip-log.txt

--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import logging
+import six
 import socket
 
 import acos_client
@@ -138,7 +139,7 @@ class Client(object):
         return VERSION_IMPORTS[self._version]["LicenseManager"](self)
 
     def wait_for_connect(self, max_timeout=60):
-        for i in range(0, max_timeout):
+        for i in six.moves.range(0, max_timeout):
             try:
                 LOG.debug("wait_for_connect: attempting %s", self.host)
                 s = socket.create_connection((self.host, self.port), 1.0)

--- a/acos_client/hash.py
+++ b/acos_client/hash.py
@@ -14,14 +14,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import hash_ring
+import uhashring
 
 
 class Hash(object):
 
     def __init__(self, server_list):
         self.server_list = server_list
-        self.ring = hash_ring.HashRing(self.server_list)
+        self.ring = uhashring.HashRing(self.server_list)
 
     def get_server(self, unique_token):
         return self.ring.get_node(unique_token)

--- a/acos_client/logutils.py
+++ b/acos_client/logutils.py
@@ -12,7 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-# import copy
+import six
 
 CLEAN_FIELDS = ["username", "password"]
 
@@ -31,9 +31,9 @@ def clean(data, field=None):
     if type(data) is dict:
         return type(data)(
             (x, clean(y, field=x))
-            for x, y in data.iteritems()
+            for x, y in six.iteritems(data)
             )
-    elif isinstance(data, basestring):
+    elif isinstance(data, six.string_types):
         return data
     elif isinstance(data, (list, tuple)):
         return type(data)(clean(x) for x in data)

--- a/acos_client/tests/t.py
+++ b/acos_client/tests/t.py
@@ -14,6 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import acos_client
 
 import argparse
 import os.path
@@ -22,8 +23,6 @@ import sys
 import traceback
 
 sys.path.append(".")
-
-import acos_client
 
 
 parser = argparse.ArgumentParser(description='acos-client smoke test')
@@ -857,6 +856,7 @@ def main():
             traceback.print_exc()
             print(e)
             sys.exit(1)
+
 
 if __name__ == '__main__':
     main()

--- a/acos_client/tests/unit/test_client.py
+++ b/acos_client/tests/unit/test_client.py
@@ -12,7 +12,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import unittest2 as unittest
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from acos_client import client
 

--- a/acos_client/tests/unit/test_cookie.py
+++ b/acos_client/tests/unit/test_cookie.py
@@ -11,12 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client.errors as acos_errors
-
-import v21_mocks as mocks
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestHttpCookiePersistence(unittest.TestCase):

--- a/acos_client/tests/unit/test_ha.py
+++ b/acos_client/tests/unit/test_ha.py
@@ -11,9 +11,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
-import v21_mocks as mocks
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestHA(unittest.TestCase):

--- a/acos_client/tests/unit/test_hash.py
+++ b/acos_client/tests/unit/test_hash.py
@@ -11,8 +11,13 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client
 

--- a/acos_client/tests/unit/test_hm.py
+++ b/acos_client/tests/unit/test_hm.py
@@ -11,12 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client.errors as acos_errors
-
-import v21_mocks as mocks
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestHealthMonitor(unittest.TestCase):

--- a/acos_client/tests/unit/test_interfaces.py
+++ b/acos_client/tests/unit/test_interfaces.py
@@ -11,9 +11,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
-import v21_mocks as mocks
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestInterfaces(unittest.TestCase):

--- a/acos_client/tests/unit/test_logutils.py
+++ b/acos_client/tests/unit/test_logutils.py
@@ -11,14 +11,22 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import mock
-import unittest2
+import six
+
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 from acos_client import logutils as target
 
 
-class TestLogutils(unittest2.TestCase):
+class TestLogutils(unittest.TestCase):
     def setUp(self):
         self.clean_fields = ["username", "password"]
 
@@ -123,8 +131,8 @@ class TestLogutils(unittest2.TestCase):
         self.assertEqual('sometext', actual)
 
     def test_ustring(self):
-        actual = target.clean(u'sometext')
-        self.assertEqual(u'sometext', actual)
+        actual = target.clean('sometext')
+        self.assertEqual('sometext', actual)
 
     def test_mock(self):
         # It's likely that clean will be called with a mock during testing.
@@ -137,5 +145,5 @@ class TestLogutils(unittest2.TestCase):
 
 class FakeObject(object):
     def __init__(self, *args, **kwargs):
-        for k, v in kwargs.iteritems():
+        for k, v in six.iteritems(kwargs):
             setattr(self, k, v)

--- a/acos_client/tests/unit/test_member.py
+++ b/acos_client/tests/unit/test_member.py
@@ -11,12 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client.errors as acos_errors
-
-import v21_mocks as mocks
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestMember(unittest.TestCase):

--- a/acos_client/tests/unit/test_partition.py
+++ b/acos_client/tests/unit/test_partition.py
@@ -11,12 +11,17 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client.errors as acos_errors
 
-import v21_mocks as mocks
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestPartition(unittest.TestCase):

--- a/acos_client/tests/unit/test_server.py
+++ b/acos_client/tests/unit/test_server.py
@@ -11,12 +11,17 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client.errors as acos_errors
 
-import v21_mocks as mocks
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestServer(unittest.TestCase):

--- a/acos_client/tests/unit/test_service_group.py
+++ b/acos_client/tests/unit/test_service_group.py
@@ -11,12 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client.errors as acos_errors
-
-import v21_mocks as mocks
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestServiceGroup(unittest.TestCase):

--- a/acos_client/tests/unit/test_session.py
+++ b/acos_client/tests/unit/test_session.py
@@ -11,11 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
-import v21_mocks as mocks
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestSession(unittest.TestCase):

--- a/acos_client/tests/unit/test_sip.py
+++ b/acos_client/tests/unit/test_sip.py
@@ -11,12 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client.errors as acos_errors
-
-import v21_mocks as mocks
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestSourceIpPersistence(unittest.TestCase):

--- a/acos_client/tests/unit/test_system.py
+++ b/acos_client/tests/unit/test_system.py
@@ -11,9 +11,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
-import v21_mocks as mocks
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestSystem(unittest.TestCase):

--- a/acos_client/tests/unit/test_virtual_port.py
+++ b/acos_client/tests/unit/test_virtual_port.py
@@ -11,12 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client.errors as acos_errors
-
-import v21_mocks as mocks
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestVirtualPort(unittest.TestCase):

--- a/acos_client/tests/unit/test_virtual_server.py
+++ b/acos_client/tests/unit/test_virtual_server.py
@@ -11,12 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import acos_client.errors as acos_errors
-
-import v21_mocks as mocks
+import acos_client.tests.unit.v21_mocks as mocks
 
 
 class TestVirtualServer(unittest.TestCase):

--- a/acos_client/tests/unit/v21_mocks.py
+++ b/acos_client/tests/unit/v21_mocks.py
@@ -11,11 +11,17 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import json
 
-import mock
-import unittest
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 import acos_client
 

--- a/acos_client/tests/unit/v30/test_dns.py
+++ b/acos_client/tests/unit/v30/test_dns.py
@@ -11,9 +11,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import mock
-import unittest2 as unittest
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 from acos_client.v30 import dns
 

--- a/acos_client/tests/unit/v30/test_interface.py
+++ b/acos_client/tests/unit/v30/test_interface.py
@@ -11,9 +11,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import mock
-import unittest2 as unittest
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 from acos_client.v30 import interface
 

--- a/acos_client/tests/unit/v30/test_license_manager.py
+++ b/acos_client/tests/unit/v30/test_license_manager.py
@@ -11,9 +11,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import mock
-import unittest2 as unittest
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 from acos_client.v30.license_manager import LicenseManager
 

--- a/acos_client/tests/unit/v30/test_member.py
+++ b/acos_client/tests/unit/v30/test_member.py
@@ -9,9 +9,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import mock
-import unittest2 as unittest
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 from acos_client import errors as acos_errors
 from acos_client.v30.slb import member
@@ -70,7 +76,7 @@ class TestMember(unittest.TestCase):
 
         ((method, url, params, header), kwargs) = self.client.http.request.call_args
 
-        self.assertEqual(url, '/axapi/v3/slb/service-group/%s/member/%s+%s/' % 
+        self.assertEqual(url, '/axapi/v3/slb/service-group/%s/member/%s+%s/' %
                               (self._sg_name,
                                expected['member']['name'],
                                expected['member']['port']))
@@ -89,7 +95,7 @@ class TestMember(unittest.TestCase):
 
         ((method, url, params, header), kwargs) = self.client.http.request.call_args
 
-        self.assertEqual(url, '/axapi/v3/slb/service-group/%s/member/%s+%s/' % 
+        self.assertEqual(url, '/axapi/v3/slb/service-group/%s/member/%s+%s/' %
                               (self._sg_name,
                                expected['member']['name'],
                                expected['member']['port']))

--- a/acos_client/tests/unit/v30/test_port.py
+++ b/acos_client/tests/unit/v30/test_port.py
@@ -9,9 +9,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import mock
-import unittest2 as unittest
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 from acos_client.v30.slb import port
 

--- a/acos_client/tests/unit/v30/test_responses.py
+++ b/acos_client/tests/unit/v30/test_responses.py
@@ -11,6 +11,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import unittest
 import uuid

--- a/acos_client/tests/unit/v30/test_service_group.py
+++ b/acos_client/tests/unit/v30/test_service_group.py
@@ -11,9 +11,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import mock
-import unittest2 as unittest
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 from acos_client.v30.slb import service_group
 

--- a/acos_client/tests/unit/v30/test_sflow.py
+++ b/acos_client/tests/unit/v30/test_sflow.py
@@ -11,9 +11,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import mock
-import unittest2 as unittest
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 from acos_client.v30 import sflow
 

--- a/acos_client/tests/unit/v30/test_slb_common.py
+++ b/acos_client/tests/unit/v30/test_slb_common.py
@@ -11,9 +11,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import mock
-import unittest2 as unittest
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 from acos_client.v30.slb import common
 

--- a/acos_client/tests/unit/v30/test_virtual_server.py
+++ b/acos_client/tests/unit/v30/test_virtual_server.py
@@ -11,10 +11,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import mock
-
-import unittest2 as unittest
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
 
 from acos_client import errors as acos_errors
 from acos_client.v30.slb import virtual_server

--- a/acos_client/v21/action.py
+++ b/acos_client/v21/action.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import six
 import time
 
 from acos_client import errors as acos_errors
@@ -46,7 +47,7 @@ class Action(base.BaseV21):
             write_cmd = "active-partition {0}\r\n{1}".format(partition, write_cmd)
 
         last_e = None
-        for i in range(0, 5):
+        for i in six.moves.range(0, 5):
             # Request raises an exception when the "maybe error" is returned.
             try:
                 return self._request("POST", "cli.deploy", params=None, payload=write_cmd, **kwargs)

--- a/acos_client/v21/slb/__init__.py
+++ b/acos_client/v21/slb/__init__.py
@@ -14,14 +14,14 @@
 
 import acos_client.v21.base as base
 
-from aflex import Aflex
-from class_list import ClassList
-from hm import HealthMonitor
-from server import Server
-from service_group import ServiceGroup
-from template import Template
-from virtual_server import VirtualServer
-from virtual_service import VirtualService
+from acos_client.v21.slb.aflex import Aflex
+from acos_client.v21.slb.class_list import ClassList
+from acos_client.v21.slb.hm import HealthMonitor
+from acos_client.v21.slb.server import Server
+from acos_client.v21.slb.service_group import ServiceGroup
+from acos_client.v21.slb.template import Template
+from acos_client.v21.slb.virtual_server import VirtualServer
+from acos_client.v21.slb.virtual_service import VirtualService
 
 
 class SLB(base.BaseV21):

--- a/acos_client/v21/slb/template/__init__.py
+++ b/acos_client/v21/slb/template/__init__.py
@@ -14,10 +14,10 @@
 
 import acos_client.v21.base as base
 
-from persistence import CookiePersistence
-from persistence import SourceIpPersistence
-from template_ssl import ClientSSL
-from template_ssl import ServerSSL
+from acos_client.v21.slb.template.persistence import CookiePersistence
+from acos_client.v21.slb.template.persistence import SourceIpPersistence
+from acos_client.v21.slb.template.template_ssl import ClientSSL
+from acos_client.v21.slb.template.template_ssl import ServerSSL
 
 
 class Template(base.BaseV21):

--- a/acos_client/v21/system.py
+++ b/acos_client/v21/system.py
@@ -23,6 +23,8 @@ from acos_client.v21.device_info import DeviceInfo
 from acos_client.v21.log import Log
 from acos_client.v21.partition import Partition
 
+import six
+
 
 class System(base.BaseV21):
     def backup(self, **kwargs):
@@ -32,6 +34,8 @@ class System(base.BaseV21):
         m = multipart.Multipart()
         m.file(name="restore", filename=name, value=data)
         ct, payload = m.get()
+        if six.PY3:
+            buffer = memoryview
         kwargs.update(payload=buffer(payload), headers={'Content-type': ct})
         return self._post("system.restore", **kwargs)
 

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 import errno
 import json
 import logging
+import six
 import socket
 import time
 
@@ -62,8 +63,9 @@ class HttpClient(object):
 
         # Update params with axapi_args for currently unsupported configuration of objects
         if axapi_args is not None:
-            formatted_axapi_args = dict([(k.replace('_', '-'), v) for k, v in
-                                        axapi_args.iteritems()])
+            formatted_axapi_args = dict(
+                [(k.replace('_', '-'), v) for k, v in six.iteritems(axapi_args)]
+            )
             params = acos_client.v21.axapi_http.merge_dicts(params, formatted_axapi_args)
 
         if (file_name is None and file_content is not None) or \
@@ -80,7 +82,7 @@ class HttpClient(object):
             # params_copy.update(extra_params)
             LOG.debug("axapi_http: params_all = %s", logutils.clean(params_copy))
 
-            payload = json.dumps(params_copy, encoding='utf-8')
+            payload = json.dumps(params_copy)
         else:
             payload = None
 
@@ -97,7 +99,7 @@ class HttpClient(object):
 
         last_e = None
 
-        for i in xrange(0, 1500):
+        for i in six.moves.range(0, 1500):
             try:
                 last_e = None
                 if file_name is not None:
@@ -122,7 +124,7 @@ class HttpClient(object):
         if last_e is not None:
             LOG.error("acos_client failing with error %s after %s retries ignoring %s",
                       last_e, i, self.retry_err_strings)
-            raise e
+            raise last_e
 
         if z.status_code == 204:
             return None

--- a/acos_client/v30/file/__init__.py
+++ b/acos_client/v30/file/__init__.py
@@ -14,8 +14,8 @@
 
 import acos_client.v30.base as base
 
-from ssl_cert import SSLCert
-from ssl_key import SSLKey
+from acos_client.v30.file.ssl_cert import SSLCert
+from acos_client.v30.file.ssl_key import SSLKey
 
 
 class File(base.BaseV30):

--- a/acos_client/v30/file/ssl_cert.py
+++ b/acos_client/v30/file/ssl_cert.py
@@ -14,6 +14,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import six
+
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
 
@@ -44,7 +46,7 @@ class SSLCert(base.BaseV30):
 
         kwargs['params'] = {'ssl-cert': {}}
 
-        for key, val in obj_params.iteritems():
+        for key, val in six.iteritems(obj_params):
             # Filter out invalid, or unset keys
             if val != "":
                 kwargs['params']['ssl-cert'][key] = val

--- a/acos_client/v30/file/ssl_key.py
+++ b/acos_client/v30/file/ssl_key.py
@@ -13,6 +13,8 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import six
+
 
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
@@ -43,7 +45,7 @@ class SSLKey(base.BaseV30):
 
         kwargs['params'] = {'ssl-key': {}}
 
-        for key, val in obj_params.iteritems():
+        for key, val in six.iteritems(obj_params):
             # Filter out invalid, or unset keys
             if val != "":
                 kwargs['params']['ssl-key'][key] = val

--- a/acos_client/v30/license_manager.py
+++ b/acos_client/v30/license_manager.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import six
 import time
 
 from acos_client import errors as acos_errors
@@ -146,7 +147,7 @@ class LicenseManager(base.BaseV30):
         # There is some lag between the setup call above and being able
         # to successfully retrieve a license.
 
-        for i in range(0, 60):
+        for i in six.moves.range(0, 60):
             try:
                 return self._post(url, payload)
             except acos_errors.ACOSException as e:
@@ -158,7 +159,7 @@ class LicenseManager(base.BaseV30):
     def paygo(self, llp_hosts=[], sn=None, instance_name=None,
               use_mgmt_port=False, interval=None, bandwidth_base=None):
 
-        for i in range(0, 4):
+        for i in six.moves.range(0, 4):
             self._paygo_setup(llp_hosts, sn, instance_name, use_mgmt_port,
                               interval, bandwidth_base)
             try:

--- a/acos_client/v30/partition.py
+++ b/acos_client/v30/partition.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import random
+import six
 import time
 
 from acos_client import errors as acos_errors
@@ -81,7 +82,7 @@ class Partition(base.BaseV30):
 
         # For concurrency's sake, since we have to lookup the id and then
         # set it, loop if we get an exists error.
-        for i in xrange(1, 1000):
+        for i in six.moves.range(1, 1000):
             try:
                 self._create(name, self._next_available_id())
                 break

--- a/acos_client/v30/slb/__init__.py
+++ b/acos_client/v30/slb/__init__.py
@@ -14,12 +14,12 @@
 
 import acos_client.v30.base as base
 
-from common import SLBCommon
-from hm import HealthMonitor
-from server import Server
-from service_group import ServiceGroup
-from template import Template
-from virtual_server import VirtualServer
+from acos_client.v30.slb.common import SLBCommon
+from acos_client.v30.slb.hm import HealthMonitor
+from acos_client.v30.slb.server import Server
+from acos_client.v30.slb.service_group import ServiceGroup
+from acos_client.v30.slb.template import Template
+from acos_client.v30.slb.virtual_server import VirtualServer
 
 
 class SLB(base.BaseV30):

--- a/acos_client/v30/slb/common.py
+++ b/acos_client/v30/slb/common.py
@@ -13,6 +13,7 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import six
 
 from acos_client.v30 import base
 
@@ -27,8 +28,8 @@ class SLBCommon(base.BaseV30):
 
     def create(self, **kwargs):
         params = {"common": {}}
-        for k, v in kwargs.items():
+        for k, v in six.iteritems(kwargs):
             params["common"][self._underscore_to_dash(k)] = v
-            del kwargs[k]
+        kwargs = {}
 
         return self._post(self.url_prefix, params, **kwargs)

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -13,6 +13,8 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import six
+
 
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
@@ -92,7 +94,7 @@ class HealthMonitor(base.BaseV30):
         config_defaults = kwargs.get("config_defaults")
 
         if config_defaults:
-            for k, v in config_defaults.iteritems():
+            for k, v in six.iteritems(config_defaults):
                 params['monitor'][k] = v
 
         if update:

--- a/acos_client/v30/slb/member.py
+++ b/acos_client/v30/slb/member.py
@@ -13,6 +13,8 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import six
+
 
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
@@ -71,9 +73,8 @@ class Member(base.BaseV30):
         config_defaults = kwargs.get("config_defaults")
 
         if config_defaults:
-            for k, v in config_defaults.iteritems():
+            for k, v in six.iteritems(config_defaults):
                 params['member'][k] = v
-
 
         self._post(url, params, **kwargs)
 

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -13,6 +13,8 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import six
+
 
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
@@ -38,7 +40,7 @@ class Server(base.BaseV30):
         config_defaults = kwargs.get("config_defaults")
 
         if config_defaults:
-            for k, v in config_defaults.iteritems():
+            for k, v in six.iteritems(config_defaults):
                 params['server'][k] = v
 
         # Two creates in a row apparently works in ACOS 4.0; stop that

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -13,6 +13,8 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import six
+
 
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
@@ -94,7 +96,7 @@ class ServiceGroup(base.BaseV30):
         config_defaults = kwargs.get("config_defaults")
 
         if config_defaults:
-            for k, v in config_defaults.iteritems():
+            for k, v in six.iteritems(config_defaults):
                 params['service-group'][k] = v
 
         if not update:

--- a/acos_client/v30/slb/template/__init__.py
+++ b/acos_client/v30/slb/template/__init__.py
@@ -14,10 +14,10 @@
 
 import acos_client.v30.base as base
 
-from persistence import CookiePersistence
-from persistence import SourceIpPersistence
-from ssl import ClientSSL
-from ssl import ServerSSL
+from acos_client.v30.slb.template.persistence import CookiePersistence
+from acos_client.v30.slb.template.persistence import SourceIpPersistence
+from acos_client.v30.slb.template.ssl import ClientSSL
+from acos_client.v30.slb.template.ssl import ServerSSL
 
 
 class Template(base.BaseV30):

--- a/acos_client/v30/slb/template/ssl.py
+++ b/acos_client/v30/slb/template/ssl.py
@@ -13,6 +13,8 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import six
+
 
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
@@ -58,7 +60,7 @@ class BaseSSL(base.BaseV30):
         }
 
         params = {'%s-ssl' % self.prefix: {}}
-        for key, val in obj_params.iteritems():
+        for key, val in six.iteritems(obj_params):
             # Filter out invalid, or unset keys
             if val != "":
                 params['%s-ssl' % self.prefix][key] = val

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -13,6 +13,8 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import six
+
 
 from acos_client import errors as ae
 from acos_client.v30 import base
@@ -98,7 +100,7 @@ class VirtualPort(base.BaseV30):
         vport_defaults = kwargs.get("vport_defaults")
 
         if vport_defaults:
-            for k, v in vport_defaults.iteritems():
+            for k, v in six.iteritems(vport_defaults):
                 params['port'][k] = v
 
         if server_ssl_tmpl:

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -13,6 +13,8 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
+import six
+
 
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
@@ -44,12 +46,10 @@ class VirtualServer(base.BaseV30):
         if vrid:
             params['virtual-server']['vrid'] = vrid
 
-
         config_defaults = kwargs.get("config_defaults")
         if config_defaults:
-            for k, v in config_defaults.iteritems():
+            for k, v in six.iteritems(config_defaults):
                 params['virtual-server'][k] = v
-
 
         if not update:
             name = ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-hash_ring>=1.3.1,<1.4.0
 requests>=2.3.0
+uhashring>=1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 hacking>=0.10,<0.11
-mock>=1.0.1
-unittest2
+mock>=1.0.1; python_version < '3.0'
+unittest2; python_version < '3.0'
 nose

--- a/tox.ini
+++ b/tox.ini
@@ -4,25 +4,23 @@
 # and then run "tox" from this directory.
 
 [tox]
-#envlist = py26,py27,pypy,py33,py34,pep8
-envlist = py26,py27,pypy,pep8
+envlist = py{26,27,py2,33,34,35,36,py3},pep8
 
 [testenv]
-basepython = 
-    py27: python2.7
-    pep8: python2.7
-	
-setenv = VIRTUAL_ENV={envdir}
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+    PYTHONHASHSEED=42
+    VIRTUAL_ENV={envdir}
 usedevelop = True
 install_command = pip install -U {opts} {packages}
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
-commands =
-  nosetests {posargs}
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+commands = nosetests {posargs}
 
 [testenv:pep8]
-commands =
-  flake8
+basepython = python3.6
+commands = flake8
 
 [flake8]
 #ignore = E122,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H302,H304,H305,H307,H401,H402,H404,H405,H904


### PR DESCRIPTION
This PR will add Python support for acos_client for Python3.3, 3.4, 3.5, 3.6 and PyPy3.3

The major changes in this PR include:
* Changing all local imports to absolute imports.
* Add code to try importing 'unittest' first and then fall back to unittest2
* Introducing use of the `six` library to provide Python3 support and maintain Python2 compatibility.
* Deprecating use of `hash_ring` in favor of `uhashring`.   `hash_ring` does not seem to provide updated packages through pip thought would support Python3, as reported in https://github.com/Doist/hash_ring/issues/17, which as of this PR is 3 years old.  `uhashring` supports Python3 and seems to have a more active developer community: https://github.com/ultrabug/uhashring.
* Removing `encoding='utf-8'` from `json.dumps()`.  The `encodings` parameter is not supported in Python3 and `encoding='utf-8'` is the default for the `encodings` parameter in Python2.
* In `acos_client/v21/system.py` we had to introduce a small amount of code to check for the python version to remap the use of `buffer` to `memoryview1` for Python3.  There didn't seem to be a more elegant solution for this particular issue.
* In `acos_client/tests/unit/test_logutils.py` there was an issue with windows line endings picked up by flake8.  The only solution that seemed to work was deleting and recreating the file.  The only actual change in the file is the removal of windows line endings and the change to `iteritems` from the `six` library.
* In `acos_client/v30/slb/common.py` the `create` method deletes keys from the dictionary which is an issue in Python3.  It seemed like the intention was to get rid of all keys from the dictionary once the key's value had been moved to another dictionary, so we decided to just initialize the `kwargs` dictionary again at the end of the method.
* Refactor `tox.ini` file to include multiple Python versions in tests.