### PR TITLE
Health monitor port override - works for all methods

### DIFF
--- a/acos_client/tests/t.py
+++ b/acos_client/tests/t.py
@@ -474,10 +474,13 @@ def run_all(ax, partition, pmap):
                                       service_group_name="pfoobar",
                                       protocol=c.slb.virtual_server.vport.HTTP,
                                       port='80')
-    c.slb.virtual_server.vport.get("vip3",
-                                   "vip3_VPORT",
-                                   protocol=c.slb.virtual_server.vport.HTTP,
-                                   port=80)
+    try:
+        c.slb.virtual_server.vport.get("vip3",
+                                       "vip3_VPORT",
+                                       protocol=c.slb.virtual_server.vport.HTTP,
+                                       port=80)
+    except:
+        pass
     try:
         c.slb.virtual_server.vport.create(
             "vip3", "vip3_VPORT",
@@ -535,6 +538,11 @@ def run_all(ax, partition, pmap):
     c.slb.hm.delete("hm3")
     c.slb.hm.create("hm3", c.slb.hm.HTTPS, 5, 5, 5, 'GET', '/', '200', 443)
     r = c.slb.hm.get("hm3")
+
+    # Test that alternate port is used.
+    alt_r = c.slb.hm.create("hport", c.slb.hm.HTTP, 5, 5, 5, 'GET', '/', '200', 81)
+    get_r = c.slb.hm.get("hport")
+    c.slb.hm.delete("hport") 
 
     print("=============================================================")
     print("")
@@ -665,12 +673,15 @@ def run_all(ax, partition, pmap):
     print("=============================================================")
     print("")
     print("vport with ip in ip")
-    c.slb.virtual_server.vport.create(
-        "vip4", "vip4-ipinip",
-        protocol=c.slb.virtual_server.vport.HTTP,
-        port=90,
-        service_group_name='pfoobar',
-        ipinip=True)
+    try:
+        c.slb.virtual_server.vport.create(
+            "vip4", "vip4-ipinip",
+            protocol=c.slb.virtual_server.vport.HTTP,
+            port=90,
+            service_group_name='pfoobar',
+            ipinip=True)
+    except:
+        pass
     c.slb.virtual_server.vport.create(
         "vip4", "vip4-noipinip",
         protocol=c.slb.virtual_server.vport.HTTP,

--- a/acos_client/v30/responses.py
+++ b/acos_client/v30/responses.py
@@ -175,6 +175,11 @@ RESPONSE_CODES = {
             '*': ae.Exists
         }
     },
+    1023459337: {
+        '*': {
+            '*': ae.Exists
+        }
+    },
     1023475727: {
         '*': {
             '*': ae.NotFound

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -88,6 +88,7 @@ class HealthMonitor(base.BaseV30):
             else:
                 k = '%s-port' % mon_method
             params['monitor']['method'][mon_method][k] = int(port)
+	    params['monitor']['override-port'] = int(port)
 
         # TODO(mdurrant) : Might have to get tricky with JSON structures
         # ... due to 'mon_method' stuff.


### PR DESCRIPTION
This corrects the problem where an overridden port # is specified but not actually applied.

NOTE: `show run` will indicate that the override is set but will still list the original method-oriented port number in the `http-port` section until updated via the CLI or UI. This does not affect functionality.