### PR TITLE
Add a definitive session.close() in axapi_http v21 and v30

### DIFF
--- a/acos_client/v21/axapi_http.py
+++ b/acos_client/v21/axapi_http.py
@@ -139,6 +139,8 @@ class HttpClient(object):
             LOG.error("acos_client failing with error %s after 60 retries",
                       e.__class__.__name__)
             raise e
+        finally:
+            session.close()
 
         # Log if the reponse is one of the known broken response
         if device_response in broken_replies:

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -110,6 +110,8 @@ class HttpClient(object):
             LOG.error("acos_client failing with error %s after 60 retries",
                       e.__class__.__name__)
             raise e
+        finally:
+            session.close()
 
         # Validate json response
         try:


### PR DESCRIPTION
This PR adds the following feature to both v21 and v30 of acos_client:
- Closes requests session after attempting to connect to load-balancer