### PR TITLE
Add Connection Limit and Resume to slb.server methods

### DIFF
--- a/acos_client/tests/unit/v30/test_bladeparam.py
+++ b/acos_client/tests/unit/v30/test_bladeparam.py
@@ -11,6 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
@@ -85,37 +86,42 @@ class TestBlade(unittest.TestCase):
 
     def test_blade_create(self):
         self.target.create(4)
-        self.client.http.request.assert_called_with("POST", self.url_prefix.format(4),
-            self._expected_payload(), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "POST", self.url_prefix.format(4), self._expected_payload(), mock.ANY
+        )
 
     def test_blade_create_priority(self):
         self.target.create(4, 122)
-        self.client.http.request.assert_called_with("POST", self.url_prefix.format(4),
-            self._expected_payload(122), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "POST", self.url_prefix.format(4), self._expected_payload(122), mock.ANY
+        )
 
     def test_blade_create_interface(self):
         interface = self._build_interface()
 
         self.target.add_interface()
         self.target.create(4)
-        self.client.http.request.assert_called_with("POST", self.url_prefix.format(4),
-            self._expected_payload(interface=interface), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "POST", self.url_prefix.format(4), self._expected_payload(interface=interface), mock.ANY
+        )
 
     def test_blade_create_gateway(self):
         gateway = self._build_ipv4gateway('1.1.1.1')
 
         self.target.add_ipv4gateway('1.1.1.1')
         self.target.create(4)
-        self.client.http.request.assert_called_with("POST", self.url_prefix.format(4),
-            self._expected_payload(gateway=gateway), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "POST", self.url_prefix.format(4), self._expected_payload(gateway=gateway), mock.ANY
+        )
 
     def test_blade_create_gateway_ipv6(self):
         gateway = self._build_ipv6gateway('1.1.1.1')
 
         self.target.add_ipv6gateway('1.1.1.1')
         self.target.create(4)
-        self.client.http.request.assert_called_with("POST", self.url_prefix.format(4),
-            self._expected_payload(gateway=gateway), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "POST", self.url_prefix.format(4), self._expected_payload(gateway=gateway), mock.ANY
+        )
 
     def test_blade_create_interface_gateway(self):
         interface = self._build_interface()
@@ -124,42 +130,48 @@ class TestBlade(unittest.TestCase):
         self.target.add_interface()
         self.target.add_ipv4gateway('1.1.1.1')
         self.target.create(4)
-        self.client.http.request.assert_called_with("POST", self.url_prefix.format(4),
-            self._expected_payload(interface=interface, gateway=gateway), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "POST", self.url_prefix.format(4), self._expected_payload(interface=interface, gateway=gateway), mock.ANY
+        )
 
     def test_blade_update(self):
         self.target.update(4)
-        self.client.http.request.assert_called_with("PUT", self.url_prefix.format(4),
-            self._expected_payload(), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "PUT", self.url_prefix.format(4), self._expected_payload(), mock.ANY
+        )
 
     def test_blade_update_priority(self):
         self.target.update(4, 122)
-        self.client.http.request.assert_called_with("PUT", self.url_prefix.format(4),
-            self._expected_payload(122), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "PUT", self.url_prefix.format(4), self._expected_payload(122), mock.ANY
+        )
 
     def test_blade_update_interface(self):
         interface = self._build_interface()
 
         self.target.add_interface()
         self.target.update(4)
-        self.client.http.request.assert_called_with("PUT", self.url_prefix.format(4),
-            self._expected_payload(interface=interface), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "PUT", self.url_prefix.format(4), self._expected_payload(interface=interface), mock.ANY
+        )
 
     def test_blade_update_gateway(self):
         gateway = self._build_ipv4gateway('1.1.1.1')
 
         self.target.add_ipv4gateway('1.1.1.1')
         self.target.update(4)
-        self.client.http.request.assert_called_with("PUT", self.url_prefix.format(4),
-            self._expected_payload(gateway=gateway), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "PUT", self.url_prefix.format(4), self._expected_payload(gateway=gateway), mock.ANY
+        )
 
     def test_blade_update_gateway_ipv6(self):
         gateway = self._build_ipv6gateway('1.1.1.1')
 
         self.target.add_ipv6gateway('1.1.1.1')
         self.target.update(4)
-        self.client.http.request.assert_called_with("PUT", self.url_prefix.format(4),
-            self._expected_payload(gateway=gateway), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "PUT", self.url_prefix.format(4), self._expected_payload(gateway=gateway), mock.ANY
+        )
 
     def test_blade_update_interface_gateway(self):
         interface = self._build_interface()
@@ -168,5 +180,6 @@ class TestBlade(unittest.TestCase):
         self.target.add_interface()
         self.target.add_ipv4gateway('1.1.1.1')
         self.target.update(4)
-        self.client.http.request.assert_called_with("PUT", self.url_prefix.format(4),
-            self._expected_payload(interface=interface, gateway=gateway), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "PUT", self.url_prefix.format(4), self._expected_payload(interface=interface, gateway=gateway), mock.ANY
+        )

--- a/acos_client/tests/unit/v30/test_vrrpa.py
+++ b/acos_client/tests/unit/v30/test_vrrpa.py
@@ -11,6 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
@@ -32,14 +33,14 @@ class TestVRID(unittest.TestCase):
 
     def expected_payload(self, vrid_val, threshold=1, disable=0):
         rv = {
-           'vrid':{
-               'vrid-val': vrid_val,
-               'preempt-mode': {
-                   'threshold': threshold,
-                   'disable': disable
-               }
-           }
-        }
+            'vrid': {
+                'vrid-val': vrid_val,
+                'preempt-mode': {
+                    'threshold': threshold,
+                    'disable': disable
+                    }
+                }
+            }
 
         return rv
 
@@ -49,20 +50,24 @@ class TestVRID(unittest.TestCase):
 
     def test_vrid_create_threshold(self):
         self.target.create(4, threshold=2)
-        self.client.http.request.assert_called_with("POST", self.url_prefix,
-            self.expected_payload(4, threshold=2), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "POST", self.url_prefix, self.expected_payload(4, threshold=2), mock.ANY
+        )
 
     def test_vrid_create_disable(self):
         self.target.create(4, disable=1)
-        self.client.http.request.assert_called_with("POST", self.url_prefix,
-            self.expected_payload(4, disable=1), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "POST", self.url_prefix, self.expected_payload(4, disable=1), mock.ANY
+        )
 
     def test_vrid_update_threshold(self):
         self.target.update(4, threshold=2)
-        self.client.http.request.assert_called_with("PUT", self.url_prefix+'4',
-            self.expected_payload(4, threshold=2), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "PUT", self.url_prefix+'4', self.expected_payload(4, threshold=2), mock.ANY
+        )
 
     def test_vrid_update_disable(self):
         self.target.update(4, disable=1)
-        self.client.http.request.assert_called_with("PUT", self.url_prefix+'4',
-            self.expected_payload(4, disable=1), mock.ANY)
+        self.client.http.request.assert_called_with(
+            "PUT", self.url_prefix+'4', self.expected_payload(4, disable=1), mock.ANY
+        )

--- a/acos_client/v21/slb/server.py
+++ b/acos_client/v21/slb/server.py
@@ -23,22 +23,26 @@ class Server(base.BaseV21):
     def get(self, name, **kwargs):
         return self._post("slb.server.search", {'name': name}, **kwargs)
 
-    def create(self, name, ip_address, **kwargs):
+    def create(self, name, ip_address, status=1, **kwargs):
         params = {
             "server": {
                 "name": name,
                 "host": ip_address,
-                "status": kwargs.get('status', 1)
+                "status": status,
+                "conn_resume": kwargs.get("conn_resume", None),
+                "conn_limit": kwargs.get("conn_limit", 8000000),
             }
         }
         self._post("slb.server.create", params, **kwargs)
 
-    def update(self, name, ip_address, **kwargs):
+    def update(self, name, ip_address, status=1, **kwargs):
         params = {
             "server": {
                 "name": name,
                 "host": ip_address,
-                "status": kwargs.get('status', 1)
+                "status": status,
+                "conn_resume": kwargs.get("conn_resume", None),
+                "conn_limit": kwargs.get("conn_limit", 8000000),
             }
         }
         self._post("slb.server.update", params, **kwargs)

--- a/acos_client/v21/slb/virtual_port.py
+++ b/acos_client/v21/slb/virtual_port.py
@@ -102,7 +102,7 @@ class VirtualPort(base.BaseV21):
 
         vports = results.get("virtual_server").get("vport_list", [])
         port_filter = lambda x: x.get("name") == name
-        filtered_vports = [port for port in vports if port_filter(port)]
+        filtered_vports = [vport for vport in vports if port_filter(vport)]
         if len(filtered_vports) > 0:
             return filtered_vports[0]
 

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -34,6 +34,8 @@ class Server(base.BaseV30):
                 "name": name,
                 "host": ip_address,
                 "action": 'enable' if status else 'disable',
+                "conn-resume": kwargs.get("conn_resume", None),
+                "conn-limit": kwargs.get("conn_limit", 8000000),
             }
         }
 
@@ -59,6 +61,8 @@ class Server(base.BaseV30):
                 "name": name,
                 "host": ip_address,
                 "action": 'enable' if status else 'disable',
+                "conn-resume": kwargs.get("conn_resume", None),
+                "conn-limit": kwargs.get("conn_limit", 8000000),
             }
         }
 

--- a/acos_client/v30/vrrpa/blade_params.py
+++ b/acos_client/v30/vrrpa/blade_params.py
@@ -18,12 +18,12 @@ from acos_client.v30 import base
 class BladeParameters(base.BaseV30):
     def __init__(self, client):
         super(BladeParameters, self).__init__(client)
-        self.base_url="/vrrp-a/vrid/{0}/blade-parameters"
+        self.base_url = "/vrrp-a/vrid/{0}/blade-parameters"
         self.interfaces = {'interface': []}
         self.gateways = {
             'gateway': {
                 'ipv4-gateway-list': [],
-                'ipv6-gateway-list': [] 
+                'ipv6-gateway-list': []
             }
         }
 
@@ -38,7 +38,7 @@ class BladeParameters(base.BaseV30):
 
         if self.gateways['gateway']['ipv4-gateway-list']:
             if rv['blade-parameters'].get('tracking-options'):
-                   rv['blade-parameters']['tracking-options'].update(self.gateways)
+                rv['blade-parameters']['tracking-options'].update(self.gateways)
             else:
                 rv['blade-parameters']['tracking-options'] = self.gateways
 
@@ -47,10 +47,10 @@ class BladeParameters(base.BaseV30):
                 if rv['blade-parameters']['tracking-options'].get('gateway'):
                     rv['blade-parameters']['tracking-options']['gateway'].update(self.gateways)
                 else:
-                   rv['blade-parameters']['tracking-options'] = self.gateways
+                    rv['blade-parameters']['tracking-options'] = self.gateways
             else:
                 rv['blade-parameters']['tracking-options'] = self.gateways
-        return rv 
+        return rv
 
     def add_interface(self, ethernet=1, priority_cost=1):
         interface = {

--- a/acos_client/v30/vrrpa/vrid.py
+++ b/acos_client/v30/vrrpa/vrid.py
@@ -21,25 +21,25 @@ class VRID(base.BaseV30):
     def __init__(self, client):
         super(VRID, self).__init__(client)
         self.client = client
-        self.base_url="/vrrp-a/vrid/"
+        self.base_url = "/vrrp-a/vrid/"
 
     @property
     def blade(self):
-        return BladeParameters(self.client) 
+        return BladeParameters(self.client)
 
     def get(self, vrid_val):
-        return self._get(self.base_url  + str(vrid_val))
+        return self._get(self.base_url + str(vrid_val))
 
     def _build_params(self, vrid_val, threshold=None, disable=None):
         vrid = {'vrid-val': vrid_val}
 
         if threshold or disable:
             threshold = threshold if threshold in range(0, 256) else 1
-            disable = disable if disable in [0,1] else 0
+            disable = disable if disable in [0, 1] else 0
             preempt = {
-                    'threshold': threshold,
-                    'disable': disable
-                }
+                'threshold': threshold,
+                'disable': disable
+            }
 
             vrid['preempt-mode'] = preempt
 


### PR DESCRIPTION
This PR adds the ability to include `conn_limit` and `conn_resume` parameters to the `slb.server.create()` and `slb.server.update()` methods.  It also fixes up some PEP8 errors that were uncovered by running tox tests.