### PR TITLE
Switch device context

### DIFF
--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -35,6 +35,7 @@ from acos_client.v21.system import System as v21_System
 from acos_client.v21.vrrp_a import VRRPA as v21_VRRPA
 
 from acos_client.v30 import axapi_http as v30_http
+from acos_client.v30.device_context import DeviceContext as v30_DeviceContext
 from acos_client.v30.dns import DNS as v30_DNS
 from acos_client.v30.file import File as v30_File
 from acos_client.v30.ha import HA as v30_HA
@@ -50,7 +51,6 @@ from acos_client.v30.slb import SLB as v30_SLB
 from acos_client.v30.system import System as v30_System
 from acos_client.v30.vlan import Vlan as v30_Vlan
 from acos_client.v30.vrrpa.vrid import VRID as v30_VRRPA
-from acos_client.v30.device_context import DeviceContext as v30_DeviceContext
 
 VERSION_IMPORTS = {
     '21': {

--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -50,6 +50,7 @@ from acos_client.v30.slb import SLB as v30_SLB
 from acos_client.v30.system import System as v30_System
 from acos_client.v30.vlan import Vlan as v30_Vlan
 from acos_client.v30.vrrpa.vrid import VRID as v30_VRRPA
+from acos_client.v30.device_context import DeviceContext as v30_DeviceContext
 
 VERSION_IMPORTS = {
     '21': {
@@ -83,7 +84,8 @@ VERSION_IMPORTS = {
         'System': v30_System,
         'File': v30_File,
         'Vlan': v30_Vlan,
-        'VRRPA': v30_VRRPA
+        'VRRPA': v30_VRRPA,
+        'DeviceContext': v30_DeviceContext
     },
 }
 
@@ -174,6 +176,10 @@ class Client(object):
     @property
     def vrrpa(self):
         return VERSION_IMPORTS[self._version]["VRRPA"](self)
+
+    @property
+    def device_context(self):
+        return VERSION_IMPORTS[self._version]["DeviceContext"](self)
 
     def wait_for_connect(self, max_timeout=60):
         for i in six.moves.range(0, max_timeout):

--- a/acos_client/v30/device_context.py
+++ b/acos_client/v30/device_context.py
@@ -11,10 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-from acos_client.v30 import base
-
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+from acos_client.v30 import base
 
 
 class DeviceContext(base.BaseV30):

--- a/acos_client/v30/device_context.py
+++ b/acos_client/v30/device_context.py
@@ -37,3 +37,4 @@ class DeviceContext(base.BaseV30):
         }
         
         return payload
+    

--- a/acos_client/v30/device_context.py
+++ b/acos_client/v30/device_context.py
@@ -1,0 +1,39 @@
+# Copyright 2015, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+
+from acos_client.v30 import base
+
+
+class DeviceContext(base.BaseV30):
+    """Switching of device-contexts"""
+    url_prefix = "/device-context"
+
+    def switch(self, device_id, obj_slot_id):
+        """Switching of device-context"""
+        payload = {
+            "device-context": self._build_payload(device_id, obj_slot_id)
+        }
+
+        return self._post(self.url_prefix, payload)
+
+    def _build_payload(self, device_id, obj_slot_id):
+
+        payload = {
+            "device-id": device_id
+        }
+        
+        return payload

--- a/acos_client/v30/device_context.py
+++ b/acos_client/v30/device_context.py
@@ -35,6 +35,5 @@ class DeviceContext(base.BaseV30):
         payload = {
             "device-id": device_id
         }
-        
+
         return payload
-    

--- a/acos_client/v30/device_context.py
+++ b/acos_client/v30/device_context.py
@@ -11,11 +11,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from acos_client.v30 import base
+
 from __future__ import absolute_import
 from __future__ import unicode_literals
-
-
-from acos_client.v30 import base
 
 
 class DeviceContext(base.BaseV30):

--- a/acos_client/v30/device_context.py
+++ b/acos_client/v30/device_context.py
@@ -37,3 +37,4 @@ class DeviceContext(base.BaseV30):
         }
 
         return payload
+    

--- a/acos_client/v30/device_context.py
+++ b/acos_client/v30/device_context.py
@@ -37,4 +37,3 @@ class DeviceContext(base.BaseV30):
         }
 
         return payload
-    

--- a/acos_client/v30/route.py
+++ b/acos_client/v30/route.py
@@ -23,7 +23,7 @@ class RIB(base.BaseV30):
     url_prefix = "/ip/route/rib"
 
     def create(self, destination, mask, next_hops=[]):
-        """Create route to {destination} {mask} using {next_hops} expressed as (gateway, distance)"""
+        """Creat route to {destination} {mask} using {next_hops} expressed as (gateway, distance)"""
         payload = {
             "rib": self._build_payload(destination, mask, next_hops)
         }

--- a/acos_client/v30/route.py
+++ b/acos_client/v30/route.py
@@ -23,7 +23,7 @@ class RIB(base.BaseV30):
     url_prefix = "/ip/route/rib"
 
     def create(self, destination, mask, next_hops=[]):
-        """Creat route to {destination} {mask} using {next_hops} expressed as (gateway, distance)"""
+        """Create route to {destination} {mask} using {next_hops} expressed as (gateway, distance)"""
         payload = {
             "rib": self._build_payload(destination, mask, next_hops)
         }


### PR DESCRIPTION
After logging on as shown in the readme, switching contexts can be done using this format:

c.device_context.switch(1,0)

The first parameter is the desired device-id context to switch to and the second is used for changing the obj-slot-id.

When this command is executed A10 device specific changes can be made.