### PR TITLE
Update responses package to version 0.10.2 and fix broken tests.

### DIFF
--- a/acos_client/tests/unit/v21/test_partition.py
+++ b/acos_client/tests/unit/v21/test_partition.py
@@ -116,7 +116,7 @@ class TestPartition(unittest.TestCase):
 
     @responses.activate
     def test_system_partition_search_not_found(self):
-        responses.add(responses.POST, SEARCH_URL, json={'session_id': 'foobar'})
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {
             "response": {"status": "fail", "err": {"code": 520749062, "msg": " Partition does not exist."}}
         }

--- a/acos_client/tests/unit/v21/test_slb_health_monitor.py
+++ b/acos_client/tests/unit/v21/test_slb_health_monitor.py
@@ -120,7 +120,7 @@ class TestHealthMonitor(unittest.TestCase):
 
     @responses.activate
     def test_health_monitor_search_not_found(self):
-        responses.add(responses.POST, SEARCH_URL, json={'session_id': 'foobar'})
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {
             "response": {"status": "fail", "err": {"code": 33619968, "msg": " The monitor does not exist."}}
         }

--- a/acos_client/tests/unit/v21/test_slb_service_group.py
+++ b/acos_client/tests/unit/v21/test_slb_service_group.py
@@ -119,7 +119,7 @@ class TestSLBServerGroup(unittest.TestCase):
 
     @responses.activate
     def test_server_group_search_not_found(self):
-        responses.add(responses.POST, SEARCH_URL, json={'session_id': 'foobar'})
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {
             "response": {"status": "fail", "err": {"code": 67305473, "msg": " No such service group"}}
         }

--- a/acos_client/tests/unit/v21/test_slb_template_cookie_persistence.py
+++ b/acos_client/tests/unit/v21/test_slb_template_cookie_persistence.py
@@ -117,7 +117,7 @@ class TestSLBTemplateCookiePersistence(unittest.TestCase):
 
     @responses.activate
     def test_slb_template_persistence_search_not_found(self):
-        responses.add(responses.POST, SEARCH_URL, json={'session_id': 'foobar'})
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {
             'response': {'status': 'fail', 'err': {'code': 67371009, 'msg': ' No such Template'}}
         }

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 hacking>=0.10,<0.11
 mock>=1.0.1; python_version < '3.0'
 unittest2; python_version < '3.0'
-responses
+responses>=0.10.2


### PR DESCRIPTION
`responses` package has been updated a couple of times this month and revealed an issue with a few tests that were broken.  Those tests have been updated and a minimum version is now in `test-requirements.txt`.

Anyone already using tox for testing will need to rebuild their tox environment:
`tox -r`