### PR TITLE
Corrected "unauthorized" logic to catch new-style auth errors, added error codes

### DIFF
--- a/acos_client/v30/responses.py
+++ b/acos_client/v30/responses.py
@@ -190,6 +190,11 @@ RESPONSE_CODES = {
             '*': ae.NotFound
         }
     },
+    1208008960: {
+        "*": {
+            "/axapi/v3/logon": ae.AuthenticationFailure
+        }
+    },
     4294967295: {
         '*': {
             '*': ae.ConfigManagerNotReady


### PR DESCRIPTION
The previous auth logic looked for a value that no longer exists. This patch accounts for that change and adds the appropriate error # / exception mappings.