### PR TITLE
Correct default arp-disable to False

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_virtual_server.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_server.py
@@ -235,3 +235,27 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.GET)
         self.assertEqual(responses.calls[1].request.url, OPER_URL)
+
+    @mock.patch('acos_client.v30.slb.virtual_server.VirtualServer.get')
+    @responses.activate
+    def test_virtual_server_create_no_arp_disable(self, mocked_get):
+        mocked_get.side_effect = acos_errors.NotFound
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        params = {
+            'virtual-server': {
+                'ip-address': '192.168.2.254',
+                'name': VSERVER_NAME,
+            }
+        }
+
+        resp = self.client.slb.virtual_server.create('test', '192.168.2.254')
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+        self.assertTrue("arp-disable" not in params)

--- a/acos_client/tests/unit/v30/test_slb_virtual_server.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_server.py
@@ -256,6 +256,4 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
-        self.assertEqual(json.loads(responses.calls[1].request.body), params)
-
-        self.assertTrue("arp-disable" not in params)
+        self.assertTrue("arp-disable" not in params["virtual-server"])

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -41,7 +41,7 @@ class VirtualServer(base.BaseV30):
             "virtual-server": self.minimal_dict({
                 "name": name,
                 "ip-address": ip_address,
-                "arp-disable": int(arp_disable)
+                "arp-disable": None if arp_disable is None else int(arp_disable)
             }),
         }
         if vrid:


### PR DESCRIPTION
I added a test to catch the "arp-disable being set bug" and had to update it as we have other tests to ensure what we submit is as expected - it just ensures not specifying arp-disable results in it not being set AT ALL in the resulting JSON. This keeps backwards compatibility with bad versions of AXAPI that see "arp-disable" in the payload and ignore the value on the other side assuming it's true.

