### PR TITLE
Added extra parameters as per OM-25 and OM-26

### DIFF
--- a/acos_client/v21/slb/virtual_port.py
+++ b/acos_client/v21/slb/virtual_port.py
@@ -74,7 +74,7 @@ class VirtualPort(base.BaseV21):
         source_nat=None,
         ha_conn_mirror=None,
         no_dest_nat=None,
-        conn_limit=8000000,
+        conn_limit=None,
         tcp_template=None,
         udp_template=None,
         **kwargs
@@ -114,7 +114,7 @@ class VirtualPort(base.BaseV21):
             params['vport']['no-dest-nat'] = 1 if no_dest_nat else 0
         if ha_conn_mirror is not None:
             params['vport']['ha-conn-mirror'] = 1 if ha_conn_mirror else 0
-        if conn_limit:
+        if conn_limit is not None:
             if conn_limit > 0 and conn_limit <= 8000000:
                 params['vport']['conn-limit'] = conn_limit
 
@@ -154,7 +154,7 @@ class VirtualPort(base.BaseV21):
         source_nat_pool=None,
         ha_conn_mirror=None,
         no_dest_nat=None,
-        conn_limit=8000000,
+        conn_limit=None,
         tcp_template=None,
         udp_template=None,
         **kwargs
@@ -195,7 +195,7 @@ class VirtualPort(base.BaseV21):
         source_nat_pool=None,
         ha_conn_mirror=None,
         no_dest_nat=None,
-        conn_limit=8000000,
+        conn_limit=None,
         tcp_template=None,
         udp_template=None,
         **kwargs

--- a/acos_client/v21/slb/virtual_port.py
+++ b/acos_client/v21/slb/virtual_port.py
@@ -91,7 +91,6 @@ class VirtualPort(base.BaseV21):
                 "status": status
             })
         }
-
         client_ssl_template = kwargs.get(self.CLIENT_SSL_TMPL_KEY)
         server_ssl_template = kwargs.get(self.SERVER_SSL_TMPL_KEY)
 

--- a/acos_client/v21/slb/virtual_port.py
+++ b/acos_client/v21/slb/virtual_port.py
@@ -112,12 +112,12 @@ class VirtualPort(base.BaseV21):
         if udp_template:
             params['vport']['udp_template'] = udp_template
         if no_dest_nat is not None:
-            params["port"]["no-dest-nat"] = 1 if no_dest_nat else 0
+            params['vport']['no-dest-nat'] = 1 if no_dest_nat else 0
         if ha_conn_mirror is not None:
-            params["port"]["ha-conn-mirror"] = 1 if ha_conn_mirror else 0
+            params['vport']['ha-conn-mirror'] = 1 if ha_conn_mirror else 0
         if conn_limit:
             if conn_limit > 0 and conn_limit <= 8000000:
-                params["port"]["conn-limit"] = conn_limit
+                params['vport']['conn-limit'] = conn_limit
 
         return self._post(action, params, **kwargs)
 

--- a/acos_client/v21/slb/virtual_port.py
+++ b/acos_client/v21/slb/virtual_port.py
@@ -72,6 +72,9 @@ class VirtualPort(base.BaseV21):
         autosnat=False,
         ipinip=False,
         source_nat=None,
+        ha_conn_mirror=None,
+        no_dest_nat=None,
+        conn_limit=8000000,
         tcp_template=None,
         udp_template=None,
         **kwargs
@@ -108,6 +111,13 @@ class VirtualPort(base.BaseV21):
             params['vport']['tcp_template'] = tcp_template
         if udp_template:
             params['vport']['udp_template'] = udp_template
+        if no_dest_nat is not None:
+            params["port"]["no-dest-nat"] = 1 if no_dest_nat else 0
+        if ha_conn_mirror is not None:
+            params["port"]["ha-conn-mirror"] = 1 if ha_conn_mirror else 0
+        if conn_limit:
+            if conn_limit > 0 and conn_limit <= 8000000:
+                params["port"]["conn-limit"] = conn_limit
 
         return self._post(action, params, **kwargs)
 
@@ -143,6 +153,9 @@ class VirtualPort(base.BaseV21):
         autosnat=False,
         ipinip=False,
         source_nat_pool=None,
+        ha_conn_mirror=None,
+        no_dest_nat=None,
+        conn_limit=8000000,
         tcp_template=None,
         udp_template=None,
         **kwargs
@@ -160,6 +173,9 @@ class VirtualPort(base.BaseV21):
             autosnat=autosnat,
             ipinip=ipinip,
             source_nat=source_nat_pool,
+            ha_conn_mirror=ha_conn_mirror,
+            no_dest_nat=no_dest_nat,
+            conn_limit=conn_limit,
             tcp_template=tcp_template,
             udp_template=udp_template,
             **kwargs
@@ -178,6 +194,9 @@ class VirtualPort(base.BaseV21):
         autosnat=False,
         ipinip=False,
         source_nat_pool=None,
+        ha_conn_mirror=None,
+        no_dest_nat=None,
+        conn_limit=8000000,
         tcp_template=None,
         udp_template=None,
         **kwargs
@@ -195,6 +214,9 @@ class VirtualPort(base.BaseV21):
                 autosnat=autosnat,
                 ipinip=ipinip,
                 source_nat=source_nat_pool,
+                ha_conn_mirror=ha_conn_mirror,
+                no_dest_nat=no_dest_nat,
+                conn_limit=conn_limit,
                 tcp_template=tcp_template,
                 udp_template=udp_template,
                 **kwargs

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -82,7 +82,7 @@ class VirtualPort(base.BaseV30):
         ipinip=False,
         source_nat_pool=None,
         ha_conn_mirror=None,
-        conn_limit=8000000,
+        conn_limit=None,
         tcp_template=None,
         udp_template=None,
         exclude_minimize=None,
@@ -90,7 +90,6 @@ class VirtualPort(base.BaseV30):
         **kwargs
     ):
         exclude_minimize = [] if exclude_minimize is None else exclude_minimize
-        
         params = {
             "port": self.minimal_dict({
                 "name": name,
@@ -135,7 +134,7 @@ class VirtualPort(base.BaseV30):
             params["port"]["no-dest-nat"] = 1 if no_dest_nat else 0
         if ha_conn_mirror is not None:
             params["port"]["ha-conn-mirror"] = 1 if ha_conn_mirror else 0
-        if conn_limit:
+        if conn_limit is not None:
             if conn_limit > 0 and conn_limit <= 8000000:
                 params["port"]["conn-limit"] = conn_limit
 
@@ -162,7 +161,7 @@ class VirtualPort(base.BaseV30):
         no_dest_nat=None,
         source_nat_pool=None,
         ha_conn_mirror=None,
-        conn_limit=8000000,
+        conn_limit=None,
         tcp_template=None,
         udp_template=None,
         **kwargs
@@ -203,7 +202,7 @@ class VirtualPort(base.BaseV30):
         no_dest_nat=None,
         source_nat_pool=None,
         ha_conn_mirror=None,
-        conn_limit=8000000,
+        conn_limit=None,
         tcp_template=None,
         udp_template=None,
         **kwargs

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -81,6 +81,8 @@ class VirtualPort(base.BaseV30):
         autosnat=False,
         ipinip=False,
         source_nat_pool=None,
+        ha_conn_mirror=None,
+        conn_limit=8000000,
         tcp_template=None,
         udp_template=None,
         exclude_minimize=None,
@@ -88,7 +90,7 @@ class VirtualPort(base.BaseV30):
         **kwargs
     ):
         exclude_minimize = [] if exclude_minimize is None else exclude_minimize
-
+        import pdb; pdb.set_trace()
         params = {
             "port": self.minimal_dict({
                 "name": name,
@@ -131,6 +133,11 @@ class VirtualPort(base.BaseV30):
 
         if no_dest_nat is not None:
             params["port"]["no-dest-nat"] = 1 if no_dest_nat else 0
+        if ha_conn_mirror is not None:
+            params["port"]["ha-conn-mirror"] = 1 if ha_conn_mirror else 0
+        if conn_limit:
+            if conn_limit > 0 and conn_limit <= 8000000:
+                params["port"]["conn-limit"] = conn_limit
 
         url = self.url_server_tmpl.format(name=virtual_server_name)
         if update:
@@ -154,6 +161,8 @@ class VirtualPort(base.BaseV30):
         ipinip=False,
         no_dest_nat=None,
         source_nat_pool=None,
+        ha_conn_mirror=None,
+        conn_limit=8000000,
         tcp_template=None,
         udp_template=None,
         **kwargs
@@ -172,6 +181,8 @@ class VirtualPort(base.BaseV30):
             ipinip=ipinip,
             no_dest_nat=no_dest_nat,
             source_nat_pool=source_nat_pool,
+            ha_conn_mirror=ha_conn_mirror,
+            conn_limit=conn_limit,
             tcp_template=tcp_template,
             udp_template=udp_template,
             **kwargs
@@ -191,6 +202,8 @@ class VirtualPort(base.BaseV30):
         ipinip=False,
         no_dest_nat=None,
         source_nat_pool=None,
+        ha_conn_mirror=None,
+        conn_limit=8000000,
         tcp_template=None,
         udp_template=None,
         **kwargs
@@ -215,6 +228,8 @@ class VirtualPort(base.BaseV30):
                 ipinip,
                 no_dest_nat,
                 source_nat_pool,
+                ha_conn_mirror,
+                conn_limit,
                 tcp_template,
                 udp_template,
                 exclude_minimize=exclude,
@@ -235,6 +250,8 @@ class VirtualPort(base.BaseV30):
                 ipinip,
                 no_dest_nat,
                 source_nat_pool,
+                ha_conn_mirror,
+                conn_limit,
                 tcp_template,
                 udp_template,
                 exclude_minimize=None,

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -90,7 +90,7 @@ class VirtualPort(base.BaseV30):
         **kwargs
     ):
         exclude_minimize = [] if exclude_minimize is None else exclude_minimize
-        import pdb; pdb.set_trace()
+        
         params = {
             "port": self.minimal_dict({
                 "name": name,


### PR DESCRIPTION
modified: acos_client/v21/slb/virtual_port.py
modified:   acos_client/v30/slb/virtual_port.py

CHANGES made for OM-25 and OM-26
Added following parameters in create and update config of virtual port
for V2:
1. no_dest_nat
2. conn_limit
3. ha-conn-mirror
for v3:
1. conn_limit
2. ha-conn-mirror