### PR TITLE
Fix order of optional arguments

### DIFF
--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -20,7 +20,7 @@ from acos_client.v30 import base
 
 class Action(base.BaseV30):
 
-    def write_memory(self, destination="primary", partition="all", **kwargs):
+    def write_memory(self, partition="all", destination="primary", **kwargs):
         payload = {
             "memory": {
                 "destination": destination,
@@ -37,8 +37,8 @@ class Action(base.BaseV30):
             # If the retry loop missed this, catch it next time.
             pass
 
-    def activate_and_write(self, destination="primary", partition="all", **kwargs):
-        self.write_memory(destination, partition)
+    def activate_and_write(self, partition="all", destination="primary", **kwargs):
+        self.write_memory(partition, destination)
 
     def clideploy(self, commandlist, **kwargs):
         payload = {


### PR DESCRIPTION
Existing code in a10-neutron-lbaas calls `activate_and_write` using
the partition name as the first argument. I changes the order of the
optional arguments in both `activate_and_write` and `write_memory` for
consistency.

Note if you were calling `write_memory` directly from another tool, you will need to switch your partition and destination arguments like `write_memory(partition, destination)`