### PR TITLE
Template support for all SLB nouns - OM89

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_server.py
+++ b/acos_client/tests/unit/v30/test_slb_server.py
@@ -74,6 +74,34 @@ class TestServer(unittest.TestCase):
         with self.assertRaises(acos_errors.Exists):
             self.client.slb.server.create('test', '192.168.2.254')
 
+    @mock.patch('acos_client.v30.slb.server.Server.get')
+    @responses.activate
+    def test_server_create_with_template(self, mocked_get):
+        mocked_get.side_effect = acos_errors.NotFound
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {'foo': 'bar'}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        params = {
+            'server': {
+                'action': 'enable',
+                'conn-limit': 8000000,
+                'conn-resume': None,
+                'host': '192.168.2.254',
+                'name': VSERVER_NAME,
+                'template-server': 'test-template-server'
+            }
+        }
+        templates = {
+            "template-server": "test-template-server"
+            }
+        resp = self.client.slb.server.create('test', '192.168.2.254', server_templates=templates)
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
     @responses.activate
     def test_server_delete(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
@@ -173,6 +201,34 @@ class TestIPv6Server(unittest.TestCase):
 
         with self.assertRaises(acos_errors.Exists):
             self.client.slb.server.create('test', '2001:baad:deed:bead:daab:daad:cead:100e')
+
+    @mock.patch('acos_client.v30.slb.server.Server.get')
+    @responses.activate
+    def test_server_create_with_template(self, mocked_get):
+        mocked_get.side_effect = acos_errors.NotFound
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {'foo': 'bar'}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        params = {
+            'server': {
+                'action': 'enable',
+                'conn-limit': 8000000,
+                'conn-resume': None,
+                'host': '192.168.2.254',
+                'name': VSERVER_NAME,
+                'template-server': 'test-template-server'
+            }
+        }
+        templates = {
+            "template-server": "test-template-server"
+            }
+        resp = self.client.slb.server.create('test', '192.168.2.254', server_templates=templates)
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
     @responses.activate
     def test_server_delete(self):

--- a/acos_client/tests/unit/v30/test_slb_server.py
+++ b/acos_client/tests/unit/v30/test_slb_server.py
@@ -93,7 +93,7 @@ class TestServer(unittest.TestCase):
         }
         templates = {
             "template-server": "test-template-server"
-            }
+        }
         resp = self.client.slb.server.create('test', '192.168.2.254', server_templates=templates)
 
         self.assertEqual(resp, json_response)
@@ -221,7 +221,7 @@ class TestIPv6Server(unittest.TestCase):
         }
         templates = {
             "template-server": "test-template-server"
-            }
+        }
         resp = self.client.slb.server.create('test', '192.168.2.254', server_templates=templates)
 
         self.assertEqual(resp, json_response)

--- a/acos_client/tests/unit/v30/test_slb_service_group.py
+++ b/acos_client/tests/unit/v30/test_slb_service_group.py
@@ -23,8 +23,8 @@ except ImportError:
 
 from acos_client import client
 import acos_client.errors as acos_errors
-import responses
 import json
+import responses
 
 
 HOSTNAME = 'fake_a10'
@@ -67,7 +67,7 @@ class TestVirtualServer(unittest.TestCase):
             'template-server': 'template_sv',
             'template-port': 'template_port',
             'template-policy': 'template-pl'
-            }
+        }
         resp = self.client.slb.service_group.create('test1', service_group_templates=templates)
         params = {
             'service-group':

--- a/acos_client/tests/unit/v30/test_slb_service_group.py
+++ b/acos_client/tests/unit/v30/test_slb_service_group.py
@@ -24,6 +24,7 @@ except ImportError:
 from acos_client import client
 import acos_client.errors as acos_errors
 import responses
+import json
 
 
 HOSTNAME = 'fake_a10'
@@ -54,6 +55,73 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+
+    @mock.patch('acos_client.v30.slb.service_group.ServiceGroup.get')
+    @responses.activate
+    def test_server_group_create_with_templates(self, mocked_get):
+        mocked_get.side_effect = acos_errors.NotFound
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        templates = {
+            'template-server': 'template_sv',
+            'template-port': 'template_port',
+            'template-policy': 'template-pl'
+            }
+        resp = self.client.slb.service_group.create('test1', service_group_templates=templates)
+        params = {
+            'service-group':
+            {
+                'health-check-disable': 0,
+                'lb-method': 'round-robin',
+                'name': 'test1',
+                'protocol': 'tcp',
+                'stateless-auto-switch': 0,
+                'template-server': 'template_sv',
+                'template-port': 'template_port',
+                'template-policy': 'template-pl'
+            }
+        }
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.service_group.ServiceGroup.get')
+    @responses.activate
+    def test_server_group_create_with_partial_templates(self, mocked_get):
+        mocked_get.side_effect = acos_errors.NotFound
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+
+        templates = {
+            'template-server': 'template_sv',
+            'template-port': 'template_port',
+        }
+        resp = self.client.slb.service_group.create('test1', service_group_templates=templates)
+
+        params = {
+            'service-group':
+            {
+                'health-check-disable': 0,
+                'lb-method': 'round-robin',
+                'name': 'test1',
+                'protocol': 'tcp',
+                'stateless-auto-switch': 0,
+                'template-server': 'template_sv',
+                'template-port': 'template_port',
+                'template-policy': None
+            }
+        }
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
     @mock.patch('acos_client.v30.slb.service_group.ServiceGroup.get')
     @responses.activate

--- a/acos_client/tests/unit/v30/test_slb_virtual_port.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_port.py
@@ -173,6 +173,112 @@ class TestVirtualPort(unittest.TestCase):
 
     @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
     @responses.activate
+    def test_virtual_port_create_with_templates(self, mocked_get):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {'response': {'status': 'OK'}}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        params = {
+            'port':
+            {
+                'auto': 1,
+                'extended-stats': 1,
+                'ipinip': 1,
+                'name': 'test1_VPORT',
+                'pool': 'test_nat_pool',
+                'port-number': 80,
+                'protocol': 'http',
+                'service-group': 'pool1',
+                'tcp_template': 'test_tcp_template',
+                'template-persist-cookie': 'test_c_pers_template',
+                'template-persist-source-ip': 'test_s_pers_template',
+                'udp_template': 'test_udp_template',
+                'template-virtual-port': 'template_vp',
+                'template-tcp': 'template_tcp',
+                'template-policy': 'template_pl',
+            }
+        }
+
+        resp = self.client.slb.virtual_server.vport.create(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.HTTP,
+            port='80',
+            service_group_name='pool1',
+            s_pers_name="test_s_pers_template",
+            c_pers_name="test_c_pers_template",
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            source_nat_pool="test_nat_pool",
+            tcp_template="test_tcp_template",
+            udp_template="test_udp_template",
+            virtual_port_templates={
+            'template-virtual-port': 'template_vp',
+            'template-tcp': 'template_tcp',
+            'template-policy': 'template_pl',
+            },
+        )
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
+    @responses.activate
+    def test_virtual_port_create_with_partial_templates(self, mocked_get):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {'response': {'status': 'OK'}}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        params = {
+            'port':
+            {
+                'auto': 1,
+                'extended-stats': 1,
+                'ipinip': 1,
+                'name': 'test1_VPORT',
+                'pool': 'test_nat_pool',
+                'port-number': 80,
+                'protocol': 'http',
+                'service-group': 'pool1',
+                'tcp_template': 'test_tcp_template',
+                'template-persist-cookie': 'test_c_pers_template',
+                'template-persist-source-ip': 'test_s_pers_template',
+                'udp_template': 'test_udp_template',
+                'template-virtual-port': 'template_vp',
+                'template-tcp': None,
+                'template-policy': None,
+            }
+        }
+
+        resp = self.client.slb.virtual_server.vport.create(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.HTTP,
+            port='80',
+            service_group_name='pool1',
+            s_pers_name="test_s_pers_template",
+            c_pers_name="test_c_pers_template",
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            source_nat_pool="test_nat_pool",
+            tcp_template="test_tcp_template",
+            udp_template="test_udp_template",
+            virtual_port_templates={
+                'template-virtual-port': 'template_vp'
+            },
+        )
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
+    @responses.activate
     def test_virtual_port_update_with_params(self, mocked_get):
         mocked_get.return_value = {"foo": "bar"}
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
@@ -215,6 +321,63 @@ class TestVirtualPort(unittest.TestCase):
             source_nat_pool="test_nat_pool",
             tcp_template="test_tcp_template",
             udp_template="test_udp_template",
+        )
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
+    @responses.activate
+    def test_virtual_port_update_with_templates(self, mocked_get):
+        mocked_get.return_value = {"foo": "bar"}
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, OBJECT_URL, json=json_response, status=200)
+        params = {
+            'port':
+            {
+                'auto': 1,
+                'extended-stats': 1,
+                'name': 'test1_VPORT',
+                'no-dest-nat': 1,
+                'pool': 'test_nat_pool',
+                'port-number': 80,
+                'protocol': 'http',
+                'service-group': 'pool1',
+                'ha-conn-mirror': 1,
+                'conn-limit': 50000,
+                'tcp_template': 'test_tcp_template',
+                'template-persist-cookie': 'test_c_pers_template',
+                'template-persist-source-ip': 'test_s_pers_template',
+                'udp_template': 'test_udp_template',
+                'template-virtual-port': 'template_vp',
+                'template-tcp': None,
+                'template-policy': None,
+            }
+        }
+
+        resp = self.client.slb.virtual_server.vport.update(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.HTTP,
+            port='80',
+            service_group_name='pool1',
+            s_pers_name="test_s_pers_template",
+            c_pers_name="test_c_pers_template",
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            ha_conn_mirror=1,
+            no_dest_nat=0,
+            conn_limit=50000,
+            source_nat_pool="test_nat_pool",
+            tcp_template="test_tcp_template",
+            udp_template="test_udp_template",
+            virtual_port_templates={
+                'template-virtual-port': 'template_vp'
+            },
         )
         self.assertEqual(resp, json_response)
         self.assertEqual(len(responses.calls), 2)

--- a/acos_client/tests/unit/v30/test_slb_virtual_port.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_port.py
@@ -177,26 +177,49 @@ class TestVirtualPort(unittest.TestCase):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {'response': {'status': 'OK'}}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
-        params = {
-            'port':
-            {
-                'auto': 1,
-                'extended-stats': 1,
-                'ipinip': 1,
-                'name': 'test1_VPORT',
-                'pool': 'test_nat_pool',
-                'port-number': 80,
-                'protocol': 'http',
-                'service-group': 'pool1',
-                'tcp_template': 'test_tcp_template',
-                'template-persist-cookie': 'test_c_pers_template',
-                'template-persist-source-ip': 'test_s_pers_template',
-                'udp_template': 'test_udp_template',
-                'template-virtual-port': 'template_vp',
-                'template-tcp': 'template_tcp',
-                'template-policy': 'template_pl',
+        protocol = self.client.slb.virtual_server.vport.HTTP
+        if protocol.lower() == 'http':
+            params = {
+                'port':
+                {
+                    'auto': 1,
+                    'extended-stats': 1,
+                    'ipinip': 1,
+                    'name': 'test1_VPORT',
+                    'pool': 'test_nat_pool',
+                    'port-number': 80,
+                    'protocol': 'http',
+                    'service-group': 'pool1',
+                    'tcp_template': 'test_tcp_template',
+                    'template-persist-cookie': 'test_c_pers_template',
+                    'template-persist-source-ip': 'test_s_pers_template',
+                    'udp_template': 'test_udp_template',
+                    'template-virtual-port': 'template_vp',
+                    'template-http': None,
+                    'template-policy': 'template_pl',
+                }
             }
-        }
+        else:
+            params = {
+                'port':
+                {
+                    'auto': 1,
+                    'extended-stats': 1,
+                    'ipinip': 1,
+                    'name': 'test1_VPORT',
+                    'pool': 'test_nat_pool',
+                    'port-number': 80,
+                    'protocol': 'http',
+                    'service-group': 'pool1',
+                    'tcp_template': 'test_tcp_template',
+                    'template-persist-cookie': 'test_c_pers_template',
+                    'template-persist-source-ip': 'test_s_pers_template',
+                    'udp_template': 'test_udp_template',
+                    'template-virtual-port': 'template_vp',
+                    'template-tcp': 'template_tcp',
+                    'template-policy': 'template_pl',
+                }
+            }
 
         resp = self.client.slb.virtual_server.vport.create(
             virtual_server_name=VSERVER_NAME,
@@ -213,9 +236,9 @@ class TestVirtualPort(unittest.TestCase):
             tcp_template="test_tcp_template",
             udp_template="test_udp_template",
             virtual_port_templates={
-            'template-virtual-port': 'template_vp',
-            'template-tcp': 'template_tcp',
-            'template-policy': 'template_pl',
+                'template-virtual-port': 'template_vp',
+                'template-tcp': 'template_tcp',
+                'template-policy': 'template_pl',
             },
         )
 
@@ -231,26 +254,49 @@ class TestVirtualPort(unittest.TestCase):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {'response': {'status': 'OK'}}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
-        params = {
-            'port':
-            {
-                'auto': 1,
-                'extended-stats': 1,
-                'ipinip': 1,
-                'name': 'test1_VPORT',
-                'pool': 'test_nat_pool',
-                'port-number': 80,
-                'protocol': 'http',
-                'service-group': 'pool1',
-                'tcp_template': 'test_tcp_template',
-                'template-persist-cookie': 'test_c_pers_template',
-                'template-persist-source-ip': 'test_s_pers_template',
-                'udp_template': 'test_udp_template',
-                'template-virtual-port': 'template_vp',
-                'template-tcp': None,
-                'template-policy': None,
+        protocol = self.client.slb.virtual_server.vport.HTTP
+        if protocol.lower() == 'http':
+            params = {
+                'port':
+                {
+                    'auto': 1,
+                    'extended-stats': 1,
+                    'ipinip': 1,
+                    'name': 'test1_VPORT',
+                    'pool': 'test_nat_pool',
+                    'port-number': 80,
+                    'protocol': 'http',
+                    'service-group': 'pool1',
+                    'tcp_template': 'test_tcp_template',
+                    'template-persist-cookie': 'test_c_pers_template',
+                    'template-persist-source-ip': 'test_s_pers_template',
+                    'udp_template': 'test_udp_template',
+                    'template-virtual-port': 'template_vp',
+                    'template-http': None,
+                    'template-policy': None,
+                }
             }
-        }
+        else:
+            params = {
+                'port':
+                {
+                    'auto': 1,
+                    'extended-stats': 1,
+                    'ipinip': 1,
+                    'name': 'test1_VPORT',
+                    'pool': 'test_nat_pool',
+                    'port-number': 80,
+                    'protocol': 'http',
+                    'service-group': 'pool1',
+                    'tcp_template': 'test_tcp_template',
+                    'template-persist-cookie': 'test_c_pers_template',
+                    'template-persist-source-ip': 'test_s_pers_template',
+                    'udp_template': 'test_udp_template',
+                    'template-virtual-port': 'template_vp',
+                    'template-tcp': None,
+                    'template-policy': None,
+                }
+            }
 
         resp = self.client.slb.virtual_server.vport.create(
             virtual_server_name=VSERVER_NAME,
@@ -335,29 +381,53 @@ class TestVirtualPort(unittest.TestCase):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {"foo": "bar"}
         responses.add(responses.POST, OBJECT_URL, json=json_response, status=200)
-        params = {
-            'port':
-            {
-                'auto': 1,
-                'extended-stats': 1,
-                'name': 'test1_VPORT',
-                'no-dest-nat': 1,
-                'pool': 'test_nat_pool',
-                'port-number': 80,
-                'protocol': 'http',
-                'service-group': 'pool1',
-                'ha-conn-mirror': 1,
-                'conn-limit': 50000,
-                'tcp_template': 'test_tcp_template',
-                'template-persist-cookie': 'test_c_pers_template',
-                'template-persist-source-ip': 'test_s_pers_template',
-                'udp_template': 'test_udp_template',
-                'template-virtual-port': 'template_vp',
-                'template-tcp': None,
-                'template-policy': None,
+        protocol = self.client.slb.virtual_server.vport.HTTP
+        if protocol.lower() == 'http':
+            params = {
+                'port':
+                {
+                    'auto': 1,
+                    'extended-stats': 1,
+                    'name': 'test1_VPORT',
+                    'no-dest-nat': 1,
+                    'pool': 'test_nat_pool',
+                    'port-number': 80,
+                    'protocol': 'http',
+                    'service-group': 'pool1',
+                    'ha-conn-mirror': 1,
+                    'conn-limit': 50000,
+                    'tcp_template': 'test_tcp_template',
+                    'template-persist-cookie': 'test_c_pers_template',
+                    'template-persist-source-ip': 'test_s_pers_template',
+                    'udp_template': 'test_udp_template',
+                    'template-virtual-port': 'template_vp',
+                    'template-http': None,
+                    'template-policy': None,
+                }
             }
-        }
-
+        else:
+            params = {
+                'port':
+                {
+                    'auto': 1,
+                    'extended-stats': 1,
+                    'name': 'test1_VPORT',
+                    'no-dest-nat': 1,
+                    'pool': 'test_nat_pool',
+                    'port-number': 80,
+                    'protocol': 'http',
+                    'service-group': 'pool1',
+                    'ha-conn-mirror': 1,
+                    'conn-limit': 50000,
+                    'tcp_template': 'test_tcp_template',
+                    'template-persist-cookie': 'test_c_pers_template',
+                    'template-persist-source-ip': 'test_s_pers_template',
+                    'udp_template': 'test_udp_template',
+                    'template-virtual-port': 'template_vp',
+                    'template-tcp': None,
+                    'template-policy': None,
+                }
+            }
         resp = self.client.slb.virtual_server.vport.update(
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',

--- a/acos_client/tests/unit/v30/test_slb_virtual_server.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_server.py
@@ -184,7 +184,7 @@ class TestVirtualServer(unittest.TestCase):
                 'template-logging': 'template_lg',
                 'template-policy': 'template_pl',
                 'template-scaleout': 'template_sc',
-                }
+            }
         )
 
         self.assertEqual(resp, json_response)

--- a/acos_client/tests/unit/v30/test_slb_virtual_server.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_server.py
@@ -154,6 +154,114 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
+    @mock.patch('acos_client.v30.slb.virtual_server.VirtualServer.get')
+    @responses.activate
+    def test_virtual_server_create_with_existing_template(self, mocked_get):
+        mocked_get.side_effect = acos_errors.NotFound
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        params = {
+            'virtual-server': {
+                'ip-address': '192.168.2.254',
+                'name': VSERVER_NAME,
+                'arp-disable': 1,
+                'vrid': 1,
+                'template-virtual-server': 'template_sv',
+                'template-logging': 'template_lg',
+                'template-policy': 'template_pl',
+                'template-scaleout': 'template_sc',
+            }
+        }
+
+        resp = self.client.slb.virtual_server.create(
+            name='test',
+            ip_address='192.168.2.254',
+            arp_disable=1,
+            vrid=1,
+            virtual_server_templates={
+                'template-virtual-server': 'template_sv',
+                'template-logging': 'template_lg',
+                'template-policy': 'template_pl',
+                'template-scaleout': 'template_sc',
+                }
+        )
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.virtual_server.VirtualServer.get')
+    @responses.activate
+    def test_virtual_server_create_with_non_existing_template(self, mocked_get):
+        mocked_get.side_effect = acos_errors.NotFound
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        params = {
+            'virtual-server': {
+                'ip-address': '192.168.2.254',
+                'name': VSERVER_NAME,
+                'arp-disable': 1,
+                'vrid': 1,
+                'template-virtual-server': 'template_sv2',
+                'template-logging': None,
+                'template-policy': None,
+                'template-scaleout': None,
+            }
+        }
+
+        resp = self.client.slb.virtual_server.create(
+            name='test',
+            ip_address='192.168.2.254',
+            arp_disable=1,
+            vrid=1,
+            virtual_server_templates={
+                'template-virtual-server': 'template_sv',
+            }
+        )
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertNotEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.virtual_server.VirtualServer.get')
+    @responses.activate
+    def test_virtual_server_update_with_existing_template(self, mocked_get):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, OBJECT_URL, json=json_response, status=200)
+        params = {
+            'virtual-server': {
+                'name': VSERVER_NAME,
+                'ip-address': '192.168.2.254',
+                'arp-disable': 1,
+                'vrid': 1,
+                'template-virtual-server': 'TEST_VIP_TEMPLATE',
+                'template-logging': 'template_lg',
+                'template-policy': None,
+                'template-scaleout': None,
+            }
+        }
+
+        resp = self.client.slb.virtual_server.update(
+            name='test',
+            ip_address='192.168.2.254',
+            arp_disable=1,
+            vrid=1,
+            virtual_server_templates={'template-logging': 'template_lg'}, template_virtual_server='TEST_VIP_TEMPLATE',
+        )
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
     @responses.activate
     def test_virtual_server_delete(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -28,7 +28,7 @@ class Server(base.BaseV30):
     def get(self, name, **kwargs):
         return self._get(self.url_prefix + name, **kwargs)
 
-    def create(self, name, ip_address, status=1, **kwargs):
+    def create(self, name, ip_address, status=1, server_templates=None, **kwargs):
         params = {
             "server": {
                 "name": name,
@@ -42,6 +42,10 @@ class Server(base.BaseV30):
             params['server']['server-ipv6-addr'] = ip_address
         else:
             params['server']['host'] = ip_address
+
+        if server_templates:
+            server_templates = {k: v for k, v in server_templates.items() if v}
+            params['server']['template-server'] = server_templates.get('template-server', None)
 
         config_defaults = kwargs.get("config_defaults")
 
@@ -59,7 +63,7 @@ class Server(base.BaseV30):
 
         return self._post(self.url_prefix, params, **kwargs)
 
-    def update(self, name, ip_address, status=1, **kwargs):
+    def update(self, name, ip_address, status=1, server_templates=None, **kwargs):
         params = {
             "server": {
                 "name": name,
@@ -73,6 +77,10 @@ class Server(base.BaseV30):
             params['server']['server-ipv6-addr'] = ip_address
         else:
             params['server']['host'] = ip_address
+
+        if server_templates:
+            server_templates = {k: v for k, v in server_templates.items() if v}
+            params['server']['template-server'] = server_templates.get('template-server', None)
 
         self.get(name, **kwargs)
 

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -53,7 +53,8 @@ class ServiceGroup(base.BaseV30):
     TCP = 'tcp'
     UDP = 'udp'
 
-    def _set(self, name, protocol=None, lb_method=None, service_group_templates=None, hm_name=None, update=False, **kwargs):
+    def _set(self, name, protocol=None, lb_method=None, service_group_templates=None,
+             hm_name=None, update=False, **kwargs):
 
         # Normalize "" -> None for json
         hm_name = hm_name or None
@@ -145,5 +146,7 @@ class ServiceGroup(base.BaseV30):
     def stats(self, name, *args, **kwargs):
         return self._get(self.url_prefix + name + "/stats", **kwargs)
 
-    def update(self, name, protocol=None, lb_method=None, health_monitor=None, service_group_templates=None, **kwargs):
-        return self._set(name, protocol, lb_method, hm_name=health_monitor, service_group_templates=service_group_templates, update=True, **kwargs)
+    def update(self, name, protocol=None, lb_method=None, health_monitor=None,
+               service_group_templates=None, **kwargs):
+        return self._set(name, protocol, lb_method, hm_name=health_monitor,
+                         service_group_templates=service_group_templates, update=True, **kwargs)

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -53,7 +53,7 @@ class ServiceGroup(base.BaseV30):
     TCP = 'tcp'
     UDP = 'udp'
 
-    def _set(self, name, protocol=None, lb_method=None, hm_name=None, update=False, **kwargs):
+    def _set(self, name, protocol=None, lb_method=None, service_group_templates=None, hm_name=None, update=False, **kwargs):
 
         # Normalize "" -> None for json
         hm_name = hm_name or None
@@ -89,6 +89,12 @@ class ServiceGroup(base.BaseV30):
             params['service-group']['lb-method'] = lb_method
             params['service-group']['stateless-auto-switch'] = 0
 
+        if service_group_templates:
+            service_group_templates = {k: v for k, v in service_group_templates.items() if v}
+            params['service-group']['template-server'] = service_group_templates.get('template-server', None)
+            params['service-group']['template-port'] = service_group_templates.get('template-port', None)
+            params['service-group']['template-policy'] = service_group_templates.get('template-policy', None)
+
         config_defaults = kwargs.get("config_defaults")
 
         if config_defaults:
@@ -117,7 +123,7 @@ class ServiceGroup(base.BaseV30):
     def all_oper(self, *args, **kwargs):
         return self._get(self.url_prefix + "oper", **kwargs)
 
-    def create(self, name, protocol=TCP, lb_method=ROUND_ROBIN, **kwargs):
+    def create(self, name, protocol=TCP, lb_method=ROUND_ROBIN, service_group_templates=None, **kwargs):
         try:
             self.get(name)
         except acos_errors.NotFound:
@@ -125,7 +131,7 @@ class ServiceGroup(base.BaseV30):
         else:
             raise acos_errors.Exists
 
-        return self._set(name, protocol, lb_method, **kwargs)
+        return self._set(name, protocol, lb_method, service_group_templates, **kwargs)
 
     def delete(self, name):
         return self._delete(self.url_prefix + name)
@@ -139,5 +145,5 @@ class ServiceGroup(base.BaseV30):
     def stats(self, name, *args, **kwargs):
         return self._get(self.url_prefix + name + "/stats", **kwargs)
 
-    def update(self, name, protocol=None, lb_method=None, health_monitor=None, **kwargs):
-        return self._set(name, protocol, lb_method, health_monitor, update=True, **kwargs)
+    def update(self, name, protocol=None, lb_method=None, service_group_templates=None, health_monitor=None, **kwargs):
+        return self._set(name, protocol, lb_method, health_monitor, service_group_templates, update=True, **kwargs)

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -145,5 +145,5 @@ class ServiceGroup(base.BaseV30):
     def stats(self, name, *args, **kwargs):
         return self._get(self.url_prefix + name + "/stats", **kwargs)
 
-    def update(self, name, protocol=None, lb_method=None, service_group_templates=None, health_monitor=None, **kwargs):
-        return self._set(name, protocol, lb_method, health_monitor, service_group_templates, update=True, **kwargs)
+    def update(self, name, protocol=None, lb_method=None, health_monitor=None, service_group_templates=None, **kwargs):
+        return self._set(name, protocol, lb_method, hm_name=health_monitor, service_group_templates=service_group_templates, update=True, **kwargs)

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -103,7 +103,6 @@ class VirtualPort(base.BaseV30):
             }, exclude=exclude_minimize
             )
         }
-        import pdb; pdb.set_trace()
         if virtual_port_templates:
             virtual_port_templates = {k: v for k, v in virtual_port_templates.items() if v}
             params['port']['template-virtual-port'] = virtual_port_templates.get('template-virtual-port', None)

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -83,6 +83,7 @@ class VirtualPort(base.BaseV30):
         source_nat_pool=None,
         ha_conn_mirror=None,
         conn_limit=None,
+        virtual_port_templates=None,
         tcp_template=None,
         udp_template=None,
         exclude_minimize=None,
@@ -102,6 +103,16 @@ class VirtualPort(base.BaseV30):
             }, exclude=exclude_minimize
             )
         }
+        import pdb; pdb.set_trace()
+        if virtual_port_templates:
+            virtual_port_templates = {k: v for k, v in virtual_port_templates.items() if v}
+            params['port']['template-virtual-port'] = virtual_port_templates.get('template-virtual-port', None)
+            if protocol == 'http':
+                params['port']['template-http'] = virtual_port_templates.get('template-http', None)
+            else:
+                params['port']['template-tcp'] = virtual_port_templates.get('template-tcp', None)
+            params['port']['template-policy'] = virtual_port_templates.get('template-policy', None)
+
         if autosnat:
             params['port']['auto'] = int(autosnat)
         if ipinip:
@@ -163,6 +174,7 @@ class VirtualPort(base.BaseV30):
         source_nat_pool=None,
         ha_conn_mirror=None,
         conn_limit=None,
+        virtual_port_templates=None,
         tcp_template=None,
         udp_template=None,
         **kwargs
@@ -183,6 +195,7 @@ class VirtualPort(base.BaseV30):
             source_nat_pool=source_nat_pool,
             ha_conn_mirror=ha_conn_mirror,
             conn_limit=conn_limit,
+            virtual_port_templates=virtual_port_templates,
             tcp_template=tcp_template,
             udp_template=udp_template,
             **kwargs
@@ -204,6 +217,7 @@ class VirtualPort(base.BaseV30):
         source_nat_pool=None,
         ha_conn_mirror=None,
         conn_limit=None,
+        virtual_port_templates=None,
         tcp_template=None,
         udp_template=None,
         **kwargs
@@ -230,6 +244,7 @@ class VirtualPort(base.BaseV30):
                 source_nat_pool,
                 ha_conn_mirror,
                 conn_limit,
+                virtual_port_templates,
                 tcp_template,
                 udp_template,
                 exclude_minimize=exclude,
@@ -252,6 +267,7 @@ class VirtualPort(base.BaseV30):
                 source_nat_pool,
                 ha_conn_mirror,
                 conn_limit,
+                virtual_port_templates,
                 tcp_template,
                 udp_template,
                 exclude_minimize=None,

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -35,7 +35,7 @@ class VirtualServer(base.BaseV30):
         return self._get(self.url_prefix + name)
 
     def _set(
-        self, name, ip_address=None, arp_disable=False, vrid=None, template_virtual_server=None, update=False, **kwargs
+        self, name, ip_address=None, arp_disable=False, vrid=None, virtual_server_templates=None, template_virtual_server=None, update=False, **kwargs
     ):
         params = {
             "virtual-server": self.minimal_dict({
@@ -51,6 +51,14 @@ class VirtualServer(base.BaseV30):
 
         if vrid:
             params['virtual-server']['vrid'] = int(vrid)
+        if virtual_server_templates:
+            virtual_server_templates = {k: v for k, v in virtual_server_templates.items() if v}
+            params['virtual-server']['template-virtual-server'] = virtual_server_templates.get('template-virtual-server', None)
+            params['virtual-server']['template-logging'] = virtual_server_templates.get('template-logging', None)
+            params['virtual-server']['template-policy'] = virtual_server_templates.get('template-policy', None)
+            params['virtual-server']['template-scaleout'] = virtual_server_templates.get('template-scaleout', None)
+
+        # for backward compatibility
         if template_virtual_server:
             params['virtual-server']['template-virtual-server'] = str(template_virtual_server)
 
@@ -63,7 +71,7 @@ class VirtualServer(base.BaseV30):
             name = ''
         return self._post(self.url_prefix + name, params, **kwargs)
 
-    def create(self, name, ip_address, arp_disable=False, vrid=None, template_virtual_server=None, **kwargs):
+    def create(self, name, ip_address, arp_disable=False, vrid=None, virtual_server_templates=None, template_virtual_server=None, **kwargs):
         try:
             self.get(name)
         except acos_errors.NotFound:
@@ -71,10 +79,10 @@ class VirtualServer(base.BaseV30):
         else:
             raise acos_errors.Exists
 
-        return self._set(name, ip_address, arp_disable, vrid, template_virtual_server, **kwargs)
+        return self._set(name, ip_address, arp_disable, vrid, virtual_server_templates, template_virtual_server, **kwargs)
 
-    def update(self, name, ip_address=None, arp_disable=False, vrid=None, template_virtual_server=None, **kwargs):
-        return self._set(name, ip_address, arp_disable, vrid, template_virtual_server, update=True, **kwargs)
+    def update(self, name, ip_address=None, arp_disable=False, vrid=None, virtual_server_templates=None, template_virtual_server=None, **kwargs):
+        return self._set(name, ip_address, arp_disable, vrid, virtual_server_templates, template_virtual_server, update=True, **kwargs)
 
     def delete(self, name):
         return self._delete(self.url_prefix + name)

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -52,8 +52,8 @@ class VirtualServer(base.BaseV30):
             params['virtual-server']['vrid'] = int(vrid)
         if virtual_server_templates:
             virtual_server_templates = {k: v for k, v in virtual_server_templates.items() if v}
-            params['virtual-server']['template-virtual-server'] =
-            virtual_server_templates.get('template-virtual-server', None)
+            params['virtual-server']['template-virtual-server'] = \
+                virtual_server_templates.get('template-virtual-server', None)
             params['virtual-server']['template-logging'] = virtual_server_templates.get('template-logging', None)
             params['virtual-server']['template-policy'] = virtual_server_templates.get('template-policy', None)
             params['virtual-server']['template-scaleout'] = virtual_server_templates.get('template-scaleout', None)

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -34,9 +34,8 @@ class VirtualServer(base.BaseV30):
     def get(self, name):
         return self._get(self.url_prefix + name)
 
-    def _set(
-        self, name, ip_address=None, arp_disable=False, vrid=None, virtual_server_templates=None, template_virtual_server=None, update=False, **kwargs
-    ):
+    def _set(self, name, ip_address=None, arp_disable=False, vrid=None,
+             virtual_server_templates=None, template_virtual_server=None, update=False, **kwargs):
         params = {
             "virtual-server": self.minimal_dict({
                 "name": name,
@@ -53,7 +52,8 @@ class VirtualServer(base.BaseV30):
             params['virtual-server']['vrid'] = int(vrid)
         if virtual_server_templates:
             virtual_server_templates = {k: v for k, v in virtual_server_templates.items() if v}
-            params['virtual-server']['template-virtual-server'] = virtual_server_templates.get('template-virtual-server', None)
+            params['virtual-server']['template-virtual-server'] =
+            virtual_server_templates.get('template-virtual-server', None)
             params['virtual-server']['template-logging'] = virtual_server_templates.get('template-logging', None)
             params['virtual-server']['template-policy'] = virtual_server_templates.get('template-policy', None)
             params['virtual-server']['template-scaleout'] = virtual_server_templates.get('template-scaleout', None)
@@ -71,7 +71,8 @@ class VirtualServer(base.BaseV30):
             name = ''
         return self._post(self.url_prefix + name, params, **kwargs)
 
-    def create(self, name, ip_address, arp_disable=False, vrid=None, virtual_server_templates=None, template_virtual_server=None, **kwargs):
+    def create(self, name, ip_address, arp_disable=False, vrid=None,
+               virtual_server_templates=None, template_virtual_server=None, **kwargs):
         try:
             self.get(name)
         except acos_errors.NotFound:
@@ -79,10 +80,13 @@ class VirtualServer(base.BaseV30):
         else:
             raise acos_errors.Exists
 
-        return self._set(name, ip_address, arp_disable, vrid, virtual_server_templates, template_virtual_server, **kwargs)
+        return self._set(name, ip_address, arp_disable, vrid, virtual_server_templates,
+                         template_virtual_server, **kwargs)
 
-    def update(self, name, ip_address=None, arp_disable=False, vrid=None, virtual_server_templates=None, template_virtual_server=None, **kwargs):
-        return self._set(name, ip_address, arp_disable, vrid, virtual_server_templates, template_virtual_server, update=True, **kwargs)
+    def update(self, name, ip_address=None, arp_disable=False, vrid=None,
+               virtual_server_templates=None, template_virtual_server=None, **kwargs):
+        return self._set(name, ip_address, arp_disable, vrid, virtual_server_templates,
+                         template_virtual_server, update=True, **kwargs)
 
     def delete(self, name):
         return self._delete(self.url_prefix + name)


### PR DESCRIPTION
added changes to accept templates from config file as a single JSON
Example: devices = {
    "ax1": {
        "name": "ax1",
        "host": "10.43.12.122",
        "port": 443,
        "username": "admin",
        "password": "a10",
        "autosnat": True,
        "api_version": "3.0",
        "conn-limit": "9000",
        "conn-resume": 40000,
        "no-dest-nat": 1,
        "template-virtual-server": "omkar2",
        "templates": {
           "virtual-server":{
           "template-virtual-server":"sg2",
           "template-logging" : "sg2",
           "template-policy": "sg2",
           "template-scaleout" : "",
           },
           "virtual-port":{
           "template-virtual-port": "sg2",
           "template-tcp": "sg2",
           "template-policy": "sg2",
           "template-scaleout": ""
           },
           "service-group":{
           "template-server": "sg2",
           "template-port": "sg2",
           "template-policy" : "sg2"
           },
           "server":{
           "template-server":"sg2"
           }
        }
    }
}