### PR TITLE
POST using the right URL when creating a new SSL template

### DIFF
--- a/acos_client/v30/slb/template/ssl.py
+++ b/acos_client/v30/slb/template/ssl.py
@@ -77,7 +77,10 @@ class BaseSSL(base.BaseV30):
             if not update:
                 name = ''
 
-        self._post(self.url_prefix + name, params, **kwargs)
+        if update:
+            self._post(self.url_prefix + name, params, **kwargs)
+        else:
+            self._post(self.url_prefix, params, **kwargs)
 
     def create(self, name, cert="", key="", passphrase="", cipher_template=None, **kwargs):
         if self.exists(name):


### PR DESCRIPTION
Commit 16cd4af628703e0ceaa0c3e93c27037e4dce248b broke the creation of new SSL templates.

When `update=True`, name is appended to the URL to update the existing object. Otherwise, the name is left out to create a new object.