### PR TITLE
L7policy Deletion correction 

### DIFF
--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -150,11 +150,9 @@ class VirtualPort(base.BaseV30):
                 params["port"]["conn-limit"] = conn_limit
 
         url = self.url_server_tmpl.format(name=virtual_server_name)
-
         aflex_scripts = kwargs.get("aflex-scripts", None)
-        if aflex_scripts:
+        if aflex_scripts is not None:
             params['port']['aflex-scripts'] = aflex_scripts
-
         if update:
             url += self.url_port_tmpl.format(
                 port_number=port, protocol=protocol

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -150,9 +150,11 @@ class VirtualPort(base.BaseV30):
                 params["port"]["conn-limit"] = conn_limit
 
         url = self.url_server_tmpl.format(name=virtual_server_name)
+
         aflex_scripts = kwargs.get("aflex-scripts", None)
         if aflex_scripts is not None:
             params['port']['aflex-scripts'] = aflex_scripts
+
         if update:
             url += self.url_port_tmpl.format(
                 port_number=port, protocol=protocol


### PR DESCRIPTION
While deleting single L7 Policy from SLB port, the aFlex array comes as empty, resulting in unexpected behavior of "if" condition.
Correction is required to allow empty array as an update in vport update function.

Files Changed:
acos_client/v30/slb/virtual_port.py