### PR TITLE
Octavia hm support

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_server.py
+++ b/acos_client/tests/unit/v30/test_slb_server.py
@@ -181,9 +181,9 @@ class TestIPv6Server(unittest.TestCase):
                 'action': 'enable',
                 'conn-limit': 8000000,
                 'conn-resume': None,
+                'health-check': None,
                 'server-ipv6-addr': '2001:baad:deed:bead:daab:daad:cead:100e',
                 'name': VSERVER_NAME,
-                'health-check': 'ping'
             }
         }
 
@@ -217,7 +217,7 @@ class TestIPv6Server(unittest.TestCase):
                 'conn-resume': None,
                 'host': '192.168.2.254',
                 'name': VSERVER_NAME,
-                'health-check': 'ping',
+                'health-check': None,
                 'template-server': 'test-template-server'
             }
         }

--- a/acos_client/tests/unit/v30/test_slb_server.py
+++ b/acos_client/tests/unit/v30/test_slb_server.py
@@ -183,6 +183,7 @@ class TestIPv6Server(unittest.TestCase):
                 'conn-resume': None,
                 'server-ipv6-addr': '2001:baad:deed:bead:daab:daad:cead:100e',
                 'name': VSERVER_NAME,
+                'health-check': 'ping'
             }
         }
 
@@ -216,6 +217,7 @@ class TestIPv6Server(unittest.TestCase):
                 'conn-resume': None,
                 'host': '192.168.2.254',
                 'name': VSERVER_NAME,
+                'health-check': 'ping',
                 'template-server': 'test-template-server'
             }
         }

--- a/acos_client/tests/unit/v30/test_slb_server.py
+++ b/acos_client/tests/unit/v30/test_slb_server.py
@@ -53,6 +53,7 @@ class TestServer(unittest.TestCase):
                 'action': 'enable',
                 'conn-limit': 8000000,
                 'conn-resume': None,
+                'health-check': None,
                 'host': '192.168.2.254',
                 'name': VSERVER_NAME,
             }
@@ -88,6 +89,7 @@ class TestServer(unittest.TestCase):
                 'conn-resume': None,
                 'host': '192.168.2.254',
                 'name': VSERVER_NAME,
+                'health-check': None,
                 'template-server': 'test-template-server'
             }
         }

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -40,7 +40,7 @@ class HealthMonitor(base.BaseV30):
             "udp-port": 5555,
             "force-up-with-single-healthcheck": 0
         },
-        UDP_CONNECT:{
+        UDP_CONNECT: {
         },
         HTTP: {
             "http": 1,

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -34,7 +34,7 @@ class HealthMonitor(base.BaseV30):
         ICMP: {
             "icmp": 1
         },
-         UDP: {
+        UDP: {
             "udp": 1,
             "udp-port": 5555,
             "force-up-with-single-healthcheck": 0
@@ -79,7 +79,7 @@ class HealthMonitor(base.BaseV30):
                 "method": {
                     mon_method: self._method_objects[mon_method]
                 },
-                "override-ipv4" : ipv4
+                "override-ipv4": ipv4
             }
         }
         if method:

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -115,7 +115,7 @@ class HealthMonitor(base.BaseV30):
 
         if update:
             action += name
-        self._post(action, params, **kwargs)
+        return self._post(action, params, **kwargs)
 
     def create(self, name, mon_type, interval, timeout, max_retries,
                method=None, url=None, expect_code=None, port=None, ipv4=None, **kwargs):
@@ -126,15 +126,16 @@ class HealthMonitor(base.BaseV30):
         else:
             raise acos_errors.Exists()
 
-        self._set(self.url_prefix, name, mon_type, interval, timeout,
-                  max_retries, method, url, expect_code, port, ipv4, update=False, **kwargs)
+        return self._set(self.url_prefix, name, mon_type, interval, timeout,
+                         max_retries, method, url, expect_code, port, ipv4, update=False,
+                         **kwargs)
 
     def update(self, name, mon_type, interval, timeout, max_retries,
                method=None, url=None, expect_code=None, port=None, ipv4=None, **kwargs):
         self.get(name)  # We want a NotFound if it does not exist
-        self._set(self.url_prefix, name, mon_type, interval, timeout,
-                  max_retries, method, url, expect_code, port, ipv4, update=True,
-                  **kwargs)
+        return self._set(self.url_prefix, name, mon_type, interval, timeout,
+                         max_retries, method, url, expect_code, port, ipv4, update=True,
+                         **kwargs)
 
     def delete(self, name):
-        self._delete(self.url_prefix + name)
+        return self._delete(self.url_prefix + name)

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -68,7 +68,7 @@ class HealthMonitor(base.BaseV30):
         return self._get(self.url_prefix + name, **kwargs)
 
     def _set(self, action, name, mon_method, interval, timeout, max_retries,
-             method=None, url=None, expect_code=None, port=None,  ipv4=None, update=False,
+             method=None, url=None, expect_code=None, port=None, ipv4=None, update=False,
              **kwargs):
         params = {
             "monitor": {

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -29,7 +29,6 @@ class HealthMonitor(base.BaseV30):
     HTTP = 'http'
     HTTPS = 'https'
     url_prefix = "/health/monitor/"
-    UDP_CONNECT = 'udp'
 
     _method_objects = {
         ICMP: {
@@ -37,10 +36,8 @@ class HealthMonitor(base.BaseV30):
         },
         UDP: {
             "udp": 1,
-            "udp-port": 5555,
+            "udp-port": 5550,
             "force-up-with-single-healthcheck": 0
-        },
-        UDP_CONNECT: {
         },
         HTTP: {
             "http": 1,

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -23,6 +23,7 @@ from acos_client.v30 import base
 class HealthMonitor(base.BaseV30):
 
     # Valid method objects
+    UDP = 'udp'
     ICMP = 'icmp'
     TCP = 'tcp'
     HTTP = 'http'
@@ -32,6 +33,11 @@ class HealthMonitor(base.BaseV30):
     _method_objects = {
         ICMP: {
             "icmp": 1
+        },
+         UDP: {
+            "udp": 1,
+            "udp-port": 5555,
+            "force-up-with-single-healthcheck": 0
         },
         HTTP: {
             "http": 1,
@@ -62,7 +68,7 @@ class HealthMonitor(base.BaseV30):
         return self._get(self.url_prefix + name, **kwargs)
 
     def _set(self, action, name, mon_method, interval, timeout, max_retries,
-             method=None, url=None, expect_code=None, port=None, update=False,
+             method=None, url=None, expect_code=None, port=None,  ipv4=None, update=False,
              **kwargs):
         params = {
             "monitor": {
@@ -72,7 +78,8 @@ class HealthMonitor(base.BaseV30):
                 "timeout": int(timeout),
                 "method": {
                     mon_method: self._method_objects[mon_method]
-                }
+                },
+                "override-ipv4" : ipv4
             }
         }
         if method:
@@ -111,7 +118,7 @@ class HealthMonitor(base.BaseV30):
         self._post(action, params, **kwargs)
 
     def create(self, name, mon_type, interval, timeout, max_retries,
-               method=None, url=None, expect_code=None, port=None, **kwargs):
+               method=None, url=None, expect_code=None, port=None, ipv4=None, **kwargs):
         try:
             self.get(name)
         except acos_errors.NotFound:
@@ -120,13 +127,13 @@ class HealthMonitor(base.BaseV30):
             raise acos_errors.Exists()
 
         self._set(self.url_prefix, name, mon_type, interval, timeout,
-                  max_retries, method, url, expect_code, port, **kwargs)
+                  max_retries, method, url, expect_code, port, ipv4, update=False, **kwargs)
 
     def update(self, name, mon_type, interval, timeout, max_retries,
-               method=None, url=None, expect_code=None, port=None, **kwargs):
+               method=None, url=None, expect_code=None, port=None, ipv4=None, **kwargs):
         self.get(name)  # We want a NotFound if it does not exist
         self._set(self.url_prefix, name, mon_type, interval, timeout,
-                  max_retries, method, url, expect_code, port, update=True,
+                  max_retries, method, url, expect_code, port, ipv4, update=True,
                   **kwargs)
 
     def delete(self, name):

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -29,6 +29,7 @@ class HealthMonitor(base.BaseV30):
     HTTP = 'http'
     HTTPS = 'https'
     url_prefix = "/health/monitor/"
+    UDP_CONNECT = 'udp'
 
     _method_objects = {
         ICMP: {
@@ -38,6 +39,8 @@ class HealthMonitor(base.BaseV30):
             "udp": 1,
             "udp-port": 5555,
             "force-up-with-single-healthcheck": 0
+        },
+        UDP_CONNECT:{
         },
         HTTP: {
             "http": 1,

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -35,7 +35,7 @@ class Server(base.BaseV30):
                 "action": 'enable' if status else 'disable',
                 "conn-resume": kwargs.get("conn_resume", None),
                 "conn-limit": kwargs.get("conn_limit", 8000000),
-                "health-check":  kwargs.get("health_check")
+                "health-check": kwargs.get("health_check")
             }
         }
 

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -35,7 +35,7 @@ class Server(base.BaseV30):
                 "action": 'enable' if status else 'disable',
                 "conn-resume": kwargs.get("conn_resume", None),
                 "conn-limit": kwargs.get("conn_limit", 8000000),
-                "health-check" :  kwargs.get("health_check")
+                "health-check":  kwargs.get("health_check")
             }
         }
 

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -35,6 +35,7 @@ class Server(base.BaseV30):
                 "action": 'enable' if status else 'disable',
                 "conn-resume": kwargs.get("conn_resume", None),
                 "conn-limit": kwargs.get("conn_limit", 8000000),
+                "health-check" :  kwargs.get("health_check")
             }
         }
 

--- a/acos_client/v30/slb/template/persistence.py
+++ b/acos_client/v30/slb/template/persistence.py
@@ -54,7 +54,7 @@ class CookiePersistence(BasePersistence):
         return {
             "cookie": {
                 "name": name,
-                "cookie-name" : cookie_name
+                "cookie-name": cookie_name
             }
         }
 

--- a/acos_client/v30/slb/template/persistence.py
+++ b/acos_client/v30/slb/template/persistence.py
@@ -37,7 +37,8 @@ class BasePersistence(base.BaseV30):
     def create(self, name, **kwargs):
         if self.exists(name):
             raise acos_errors.Exists
-        self._post(self.prefix, self.get_params(name), **kwargs)
+        cookie_name = kwargs.get("cookie_name", None)
+        self._post(self.prefix, self.get_params(name, cookie_name), **kwargs)
 
     def delete(self, name, **kwargs):
         self._delete(self.prefix + name, **kwargs)
@@ -49,10 +50,11 @@ class CookiePersistence(BasePersistence):
         self.pers_type = 'cookie'
         super(CookiePersistence, self).__init__(client)
 
-    def get_params(self, name):
+    def get_params(self, name, cookie_name=None):
         return {
             "cookie": {
-                "name": name
+                "name": name,
+                "cookie-name" : cookie_name
             }
         }
 
@@ -63,7 +65,7 @@ class SourceIpPersistence(BasePersistence):
         self.pers_type = 'source-ip'
         super(SourceIpPersistence, self).__init__(client)
 
-    def get_params(self, name):
+    def get_params(self, name, cookie_name=None):
         return {
             "source-ip": {
                 "name": name


### PR DESCRIPTION
## Non-Customer Highlights
- Added ipv4 as an argument for `create` hm method.
- Added UDP and UDP_CONNECT method support for `/health/monitor` API
- Added session persistence support for cookie name

Files changed 

- acos_client/tests/unit/v30/test_slb_server.py
- acos_client/v30/slb/hm.py
- acos_client/v30/slb/server.py 


## Related PRs
https://github.com/a10networks/a10-octavia/pull/28
https://github.com/a10networks/a10-octavia/pull/31


## Closes
[Stack-485](https://a10networks.atlassian.net/browse/STACK-485)
[Stack-482](https://a10networks.atlassian.net/browse/STACK-482)
