### PR TITLE
STACK-883 : Support for cookie_name for session persistence

### DIFF
--- a/acos_client/v30/slb/template/persistence.py
+++ b/acos_client/v30/slb/template/persistence.py
@@ -49,10 +49,11 @@ class CookiePersistence(BasePersistence):
         self.pers_type = 'cookie'
         super(CookiePersistence, self).__init__(client)
 
-    def get_params(self, name):
+    def get_params(self, name, cookie_name=None):
         return {
             "cookie": {
-                "name": name
+                "name": name,
+                "cookie-name": cookie_name
             }
         }
 


### PR DESCRIPTION
**Non-Customer Highlights:**
Added support for cookie_name for session persistence

**Closes:**
STACK-883