### PR TITLE
STACK-1181 changes to support use-rcv-for-resp

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_virtual_port.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_port.py
@@ -92,7 +92,8 @@ class TestVirtualPort(unittest.TestCase):
                 'tcp_template': 'test_tcp_template',
                 'template-persist-cookie': 'test_c_pers_template',
                 'template-persist-source-ip': 'test_s_pers_template',
-                'udp_template': 'test_udp_template'
+                'udp_template': 'test_udp_template',
+                'use-rcv-hop-for-resp': 1
             }
         }
 
@@ -113,6 +114,7 @@ class TestVirtualPort(unittest.TestCase):
             source_nat_pool="test_nat_pool",
             tcp_template="test_tcp_template",
             udp_template="test_udp_template",
+            use_rcv_hop=True,
         )
 
         self.assertEqual(resp, json_response)
@@ -239,6 +241,7 @@ class TestVirtualPort(unittest.TestCase):
                 'template-tcp': 'template_tcp',
                 'template-policy': 'template_pl',
             },
+            use_rcv_hop=False,
         )
 
         self.assertEqual(resp, json_response)
@@ -347,6 +350,7 @@ class TestVirtualPort(unittest.TestCase):
                 'template-persist-cookie': 'test_c_pers_template',
                 'template-persist-source-ip': 'test_s_pers_template',
                 'udp_template': 'test_udp_template',
+                'use-rcv-hop-for-resp': 1,
             }
         }
 
@@ -367,6 +371,7 @@ class TestVirtualPort(unittest.TestCase):
             source_nat_pool="test_nat_pool",
             tcp_template="test_tcp_template",
             udp_template="test_udp_template",
+            use_rcv_hop=True,
         )
         self.assertEqual(resp, json_response)
         self.assertEqual(len(responses.calls), 2)
@@ -450,6 +455,7 @@ class TestVirtualPort(unittest.TestCase):
             virtual_port_templates={
                 'template-virtual-port': 'template_vp'
             },
+            use_rcv_hop=False,
         )
         self.assertEqual(resp, json_response)
         self.assertEqual(len(responses.calls), 2)

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -82,6 +82,7 @@ class VirtualPort(base.BaseV30):
         ipinip=False,
         source_nat_pool=None,
         ha_conn_mirror=None,
+        use_rcv_hop=False,
         conn_limit=None,
         virtual_port_templates=None,
         tcp_template=None,
@@ -116,6 +117,8 @@ class VirtualPort(base.BaseV30):
             params['port']['auto'] = int(autosnat)
         if ipinip:
             params['port']['ipinip'] = int(ipinip)
+        if use_rcv_hop:
+            params['port']['use-rcv-hop-for-resp'] = int(use_rcv_hop)
         if source_nat_pool and len(source_nat_pool) > 0:
             params['port']['pool'] = source_nat_pool
         if tcp_template:
@@ -177,6 +180,7 @@ class VirtualPort(base.BaseV30):
         no_dest_nat=None,
         source_nat_pool=None,
         ha_conn_mirror=None,
+        use_rcv_hop=False,
         conn_limit=None,
         virtual_port_templates=None,
         tcp_template=None,
@@ -198,6 +202,7 @@ class VirtualPort(base.BaseV30):
             no_dest_nat=no_dest_nat,
             source_nat_pool=source_nat_pool,
             ha_conn_mirror=ha_conn_mirror,
+            use_rcv_hop=use_rcv_hop,
             conn_limit=conn_limit,
             virtual_port_templates=virtual_port_templates,
             tcp_template=tcp_template,
@@ -220,6 +225,7 @@ class VirtualPort(base.BaseV30):
         no_dest_nat=None,
         source_nat_pool=None,
         ha_conn_mirror=None,
+        use_rcv_hop=False,
         conn_limit=None,
         virtual_port_templates=None,
         tcp_template=None,
@@ -247,6 +253,7 @@ class VirtualPort(base.BaseV30):
                 no_dest_nat=no_dest_nat,
                 source_nat_pool=source_nat_pool,
                 ha_conn_mirror=ha_conn_mirror,
+                use_rcv_hop=use_rcv_hop,
                 conn_limit=conn_limit,
                 virtual_port_templates=virtual_port_templates,
                 tcp_template=tcp_template,
@@ -270,6 +277,7 @@ class VirtualPort(base.BaseV30):
                 no_dest_nat=no_dest_nat,
                 source_nat_pool=source_nat_pool,
                 ha_conn_mirror=ha_conn_mirror,
+                use_rcv_hop=use_rcv_hop,
                 conn_limit=conn_limit,
                 virtual_port_templates=virtual_port_templates,
                 tcp_template=tcp_template,


### PR DESCRIPTION
Checked use_rcv_hop for virtual port creation through a10-octavia.