### PR TITLE
STACK-1217: Added floating_ip param to vrid create and update API

### DIFF
--- a/acos_client/tests/unit/v30/test_vrrpa.py
+++ b/acos_client/tests/unit/v30/test_vrrpa.py
@@ -55,7 +55,6 @@ class TestVRID(unittest.TestCase):
         self.client.http.request.assert_called_with("GET", self.url_prefix + '0', {}, mock.ANY)
 
     def test_vrid_create_threshold(self):
-        import pdb; pdb.set_trace()
         self.target.create(4, threshold=2)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix, self.expected_payload(4, threshold=2), mock.ANY)

--- a/acos_client/tests/unit/v30/test_vrrpa.py
+++ b/acos_client/tests/unit/v30/test_vrrpa.py
@@ -39,13 +39,14 @@ class TestVRID(unittest.TestCase):
                     'threshold': threshold,
                     'disable': disable
                 }
-            },
-            'floating-ip': {
+            }
+        }
+        if floating_ip:
+            rv['floating-ip'] = {
                 'ip-address-cfg': [{
                     'ip-address': floating_ip
                 }]
             }
-        }
 
         return rv
 
@@ -54,6 +55,7 @@ class TestVRID(unittest.TestCase):
         self.client.http.request.assert_called_with("GET", self.url_prefix + '0', {}, mock.ANY)
 
     def test_vrid_create_threshold(self):
+        import pdb; pdb.set_trace()
         self.target.create(4, threshold=2)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix, self.expected_payload(4, threshold=2), mock.ANY)
@@ -64,7 +66,7 @@ class TestVRID(unittest.TestCase):
             "POST", self.url_prefix, self.expected_payload(4, disable=1), mock.ANY)
 
     def test_vrid_create_floating_ip(self):
-        self.target.create(4, floating_ip='10.10.10.8')
+        self.target.create(4, threshold=1, disable=0, floating_ip='10.10.10.8')
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix, self.expected_payload(4, floating_ip='10.10.10.8'),
             mock.ANY)
@@ -80,7 +82,7 @@ class TestVRID(unittest.TestCase):
             "PUT", self.url_prefix + '4', self.expected_payload(4, disable=1), mock.ANY)
 
     def test_vrid_update_floating_ip(self):
-        self.target.update(4, floating_ip='10.10.10.9')
+        self.target.update(4, threshold=1, disable=0, floating_ip='10.10.10.9')
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix + '4', self.expected_payload(4, floating_ip='10.10.10.9'),
             mock.ANY)

--- a/acos_client/tests/unit/v30/test_vrrpa.py
+++ b/acos_client/tests/unit/v30/test_vrrpa.py
@@ -31,7 +31,7 @@ class TestVRID(unittest.TestCase):
         self.target = vrid.VRID(self.client)
         self.url_prefix = "/axapi/v3/vrrp-a/vrid/"
 
-    def expected_payload(self, vrid_val, threshold=1, disable=0):
+    def expected_payload(self, vrid_val, threshold=1, disable=0, floating_ip=None):
         rv = {
             'vrid': {
                 'vrid-val': vrid_val,
@@ -39,6 +39,11 @@ class TestVRID(unittest.TestCase):
                     'threshold': threshold,
                     'disable': disable
                 }
+            },
+            'floating-ip' : {
+                'ip-address-cfg' :[{
+                    'ip-address' : floating_ip
+                }] 
             }
         }
 
@@ -58,6 +63,12 @@ class TestVRID(unittest.TestCase):
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix, self.expected_payload(4, disable=1), mock.ANY)
 
+    def test_vrid_create_floating_ip(self):
+        self.target.create(4, floating_ip='10.10.10.8')
+        self.client.http.request.assert_called_with(
+            "POST", self.url_prefix, self.expected_payload(4, floating_ip='10.10.10.8'),
+            mock.ANY)
+
     def test_vrid_update_threshold(self):
         self.target.update(4, threshold=2)
         self.client.http.request.assert_called_with(
@@ -67,3 +78,10 @@ class TestVRID(unittest.TestCase):
         self.target.update(4, disable=1)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix + '4', self.expected_payload(4, disable=1), mock.ANY)
+
+    def test_vrid_update_floating_ip(self):
+        self.target.update(4, floating_ip='10.10.10.9')
+        self.client.http.request.assert_called_with(
+            "PUT", self.url_prefix + '4', self.expected_payload(4, floating_ip='10.10.10.9'),
+            mock.ANY)
+

--- a/acos_client/tests/unit/v30/test_vrrpa.py
+++ b/acos_client/tests/unit/v30/test_vrrpa.py
@@ -42,7 +42,7 @@ class TestVRID(unittest.TestCase):
             }
         }
         if floating_ip:
-            rv['floating-ip'] = {
+            rv['vrid']['floating-ip'] = {
                 'ip-address-cfg': [{
                     'ip-address': floating_ip
                 }]

--- a/acos_client/tests/unit/v30/test_vrrpa.py
+++ b/acos_client/tests/unit/v30/test_vrrpa.py
@@ -40,10 +40,10 @@ class TestVRID(unittest.TestCase):
                     'disable': disable
                 }
             },
-            'floating-ip' : {
-                'ip-address-cfg' :[{
-                    'ip-address' : floating_ip
-                }] 
+            'floating-ip': {
+                'ip-address-cfg': [{
+                    'ip-address': floating_ip
+                }]
             }
         }
 
@@ -84,4 +84,3 @@ class TestVRID(unittest.TestCase):
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix + '4', self.expected_payload(4, floating_ip='10.10.10.9'),
             mock.ANY)
-

--- a/acos_client/v30/vrrpa/vrid.py
+++ b/acos_client/v30/vrrpa/vrid.py
@@ -38,8 +38,13 @@ class VRID(base.BaseV30):
         except acos_errors.NotFound:
             return False
 
-    def _build_params(self, vrid_val, threshold=None, disable=None):
+    def _build_params(self, vrid_val, threshold=None, disable=None, floating_ip=None):
         vrid = {'vrid-val': vrid_val}
+	if floating_ip:
+            ip_address_cfg = []
+            ip_address = {'ip-address' : floating_ip}
+            ip_address_cfg.append(ip_address)
+            floating_ip_payload = {'ip-address-cfg' : ip_address_cfg}
 
         if threshold or disable:
             threshold = threshold if threshold in range(0, 256) else 1
@@ -52,14 +57,16 @@ class VRID(base.BaseV30):
             vrid['preempt-mode'] = preempt
 
         payload = {'vrid': vrid}
+        if floating_ip:
+            payload['floating-ip'] = floating_ip_payload
 
         return payload
 
-    def create(self, vrid_val, threshold=None, disable=None):
-        return self._post(self.base_url, self._build_params(vrid_val, threshold, disable))
+    def create(self, vrid_val, threshold=None, disable=None, floating_ip=None):
+        return self._post(self.base_url, self._build_params(vrid_val, threshold, disable, floating_ip))
 
-    def update(self, vrid_val, threshold=None, disable=None):
-        return self._put(self.base_url + str(vrid_val), self._build_params(vrid_val, threshold, disable))
+    def update(self, vrid_val, threshold=None, disable=None, floating_ip=None):
+        return self._put(self.base_url + str(vrid_val), self._build_params(vrid_val, threshold, disable, floating_ip))
 
     def delete(self, vrid_val):
         return self._delete(self.base_url + str(vrid_val))

--- a/acos_client/v30/vrrpa/vrid.py
+++ b/acos_client/v30/vrrpa/vrid.py
@@ -38,14 +38,24 @@ class VRID(base.BaseV30):
         except acos_errors.NotFound:
             return False
 
-    def _build_params(self, vrid_val, threshold=None, disable=None, floating_ip=None):
+    def _build_params(self, vrid_val, threshold=None, disable=None, floating_ip=None,
+                      is_partition=False):
         vrid = {'vrid-val': vrid_val}
+
+        vrid_floating_ip = None
         if floating_ip:
-            vrid_floating_ip = {
-                'ip-address-cfg': [{
-                    'ip-address': floating_ip
-                }]
-            }
+            if is_partition:
+                vrid_floating_ip = {
+                    'ip-address-part-cfg': [{
+                        'ip-address-partition': floating_ip
+                    }]
+                }
+            else:
+                vrid_floating_ip = {
+                    'ip-address-cfg': [{
+                        'ip-address': floating_ip
+                    }]
+                }
             vrid['floating-ip'] = vrid_floating_ip
 
         if threshold or disable:
@@ -61,13 +71,14 @@ class VRID(base.BaseV30):
         payload = {'vrid': vrid}
         return payload
 
-    def create(self, vrid_val, threshold=None, disable=None, floating_ip=None):
+    def create(self, vrid_val, threshold=None, disable=None, floating_ip=None, is_partition=False):
         return self._post(self.base_url, self._build_params(vrid_val, threshold, disable,
-                                                            floating_ip))
+                                                            floating_ip, is_partition))
 
-    def update(self, vrid_val, threshold=None, disable=None, floating_ip=None):
+    def update(self, vrid_val, threshold=None, disable=None, floating_ip=None, is_partition=False):
         return self._put(self.base_url + str(vrid_val), self._build_params(vrid_val, threshold,
-                                                                           disable, floating_ip))
+                                                                           disable, floating_ip,
+                                                                           is_partition))
 
     def delete(self, vrid_val):
         return self._delete(self.base_url + str(vrid_val))

--- a/acos_client/v30/vrrpa/vrid.py
+++ b/acos_client/v30/vrrpa/vrid.py
@@ -40,11 +40,11 @@ class VRID(base.BaseV30):
 
     def _build_params(self, vrid_val, threshold=None, disable=None, floating_ip=None):
         vrid = {'vrid-val': vrid_val}
-	if floating_ip:
+        if floating_ip:
             ip_address_cfg = []
-            ip_address = {'ip-address' : floating_ip}
+            ip_address = {'ip-address': floating_ip}
             ip_address_cfg.append(ip_address)
-            floating_ip_payload = {'ip-address-cfg' : ip_address_cfg}
+            floating_ip_payload = {'ip-address-cfg': ip_address_cfg}
 
         if threshold or disable:
             threshold = threshold if threshold in range(0, 256) else 1

--- a/acos_client/v30/vrrpa/vrid.py
+++ b/acos_client/v30/vrrpa/vrid.py
@@ -41,10 +41,12 @@ class VRID(base.BaseV30):
     def _build_params(self, vrid_val, threshold=None, disable=None, floating_ip=None):
         vrid = {'vrid-val': vrid_val}
         if floating_ip:
-            ip_address_cfg = []
-            ip_address = {'ip-address': floating_ip}
-            ip_address_cfg.append(ip_address)
-            floating_ip_payload = {'ip-address-cfg': ip_address_cfg}
+            vrid_floating_ip = {
+                'ip-address-cfg': [{
+                    'ip-address': floating_ip
+                }]
+            }
+            vrid['floating-ip'] = vrid_floating_ip
 
         if threshold or disable:
             threshold = threshold if threshold in range(0, 256) else 1
@@ -57,16 +59,15 @@ class VRID(base.BaseV30):
             vrid['preempt-mode'] = preempt
 
         payload = {'vrid': vrid}
-        if floating_ip:
-            payload['floating-ip'] = floating_ip_payload
-
         return payload
 
     def create(self, vrid_val, threshold=None, disable=None, floating_ip=None):
-        return self._post(self.base_url, self._build_params(vrid_val, threshold, disable, floating_ip))
+        return self._post(self.base_url, self._build_params(vrid_val, threshold, disable,
+                                                            floating_ip))
 
     def update(self, vrid_val, threshold=None, disable=None, floating_ip=None):
-        return self._put(self.base_url + str(vrid_val), self._build_params(vrid_val, threshold, disable, floating_ip))
+        return self._put(self.base_url + str(vrid_val), self._build_params(vrid_val, threshold,
+                                                                           disable, floating_ip))
 
     def delete(self, vrid_val):
         return self._delete(self.base_url + str(vrid_val))


### PR DESCRIPTION
## Highlights
- Included `floating-ip` in payload for `create` and `update` of `/vrrp-a/vrid`

## Testing 
- Done testing via TDD only. Need to do functionality test once

## Closes 
[STACK-1217](https://a10networks.atlassian.net/browse/STACK-1217)