### PR TITLE
[STACK-1290] Added support for partition VRID floating ip configuration

### DIFF
--- a/acos_client/v30/vrrpa/vrid.py
+++ b/acos_client/v30/vrrpa/vrid.py
@@ -38,8 +38,25 @@ class VRID(base.BaseV30):
         except acos_errors.NotFound:
             return False
 
-    def _build_params(self, vrid_val, threshold=None, disable=None):
+    def _build_params(self, vrid_val, threshold=None, disable=None, floating_ip=None,
+                      is_partition=False):
         vrid = {'vrid-val': vrid_val}
+
+        vrid_floating_ip = None
+        if floating_ip:
+            if is_partition:
+                vrid_floating_ip = {
+                    'ip-address-part-cfg': [{
+                        'ip-address-partition': floating_ip
+                    }]
+                }
+            else:
+                vrid_floating_ip = {
+                    'ip-address-cfg': [{
+                        'ip-address': floating_ip
+                    }]
+                }
+            vrid['floating-ip'] = vrid_floating_ip
 
         if threshold or disable:
             threshold = threshold if threshold in range(0, 256) else 1
@@ -52,14 +69,16 @@ class VRID(base.BaseV30):
             vrid['preempt-mode'] = preempt
 
         payload = {'vrid': vrid}
-
         return payload
 
-    def create(self, vrid_val, threshold=None, disable=None):
-        return self._post(self.base_url, self._build_params(vrid_val, threshold, disable))
+    def create(self, vrid_val, threshold=None, disable=None, floating_ip=None, is_partition=False):
+        return self._post(self.base_url, self._build_params(vrid_val, threshold, disable,
+                                                            floating_ip, is_partition))
 
-    def update(self, vrid_val, threshold=None, disable=None):
-        return self._put(self.base_url + str(vrid_val), self._build_params(vrid_val, threshold, disable))
+    def update(self, vrid_val, threshold=None, disable=None, floating_ip=None, is_partition=False):
+        return self._put(self.base_url + str(vrid_val), self._build_params(vrid_val, threshold,
+                                                                           disable, floating_ip,
+                                                                           is_partition))
 
     def delete(self, vrid_val):
         return self._delete(self.base_url + str(vrid_val))


### PR DESCRIPTION
**Description**

Added support to configure VRID floating IPs in partition.

**Jira Ticket**
https://a10networks.atlassian.net/browse/STACK-1290

**Related PR**
https://github.com/a10networks/a10-octavia/pull/99

** Technical Approach**
The JSON format of partitions are different that shared partition. Added a optional parameter `is_partition`, based on it, a new JSON is created.