### PR TITLE
STACK-1389 changes to get vcs summary oper data

### DIFF
--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -106,3 +106,7 @@ class Action(base.BaseV30):
             return True
         else:
             return False
+
+    def get_vcs_summary_oper(self):
+        url = "/vcs/vcs-summary/oper"
+        return self._get(url)


### PR DESCRIPTION
Changes for addition of get_vcs_summary_oper() to get data from endpoint "/vcs/vcs-summary/oper". This API is used by changes done for https://a10networks.atlassian.net/browse/STACK-1365.