### PR TITLE
[STACK-1457]: Deleting a health monitor from pool sets pool to health-check-disable instead of just removing the hm association.

### DIFF
--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -76,6 +76,10 @@ class ServiceGroup(base.BaseV30):
         # health-check-disable and health-check at the same time.
         if hm_name is None:
             params["service-group"]["health-check-disable"] = health_check_disable
+            # Have to explicitly detach health monitor from the service group,
+            # by setting health_check parameter to None.
+            if 'health_check' in kwargs:
+                params["service-group"]["health-check"] = kwargs['health_check']
         else:
             params["service-group"]["health-check"] = hm_name
 


### PR DESCRIPTION
## Issue Description
When deleting a health monitor, health_check_disable will also get set. As per expectation, the reference of health monitor should be removed from the service group and health_check_disable attribute should be unaltered.

## Severity Level
 High

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1457

## Technical approach
1. Initially checked if removing or setting false or None health_check_disable works, axapi giving an error.
2. Compared service group create API payload with service group update API payload.
3. Statically added the health-check parameter to API payload while updating service group object, worked.
4. Integrated change with the appropriate condition.

## Manual Tests
1. Tested creation of service group object.
2. Tested update of service group object.
3. Tested delete service group object.
3. Tested the creation of health monitor.
4. Tested deletion of health monitor.

