### PR TITLE
[STACK-1589] Added support for associating multiple floating IPs with a VRID

### DIFF
--- a/acos_client/v30/vrrpa/vrid.py
+++ b/acos_client/v30/vrrpa/vrid.py
@@ -44,12 +44,12 @@ class VRID(base.BaseV30):
         vrid_floating_ips = None
         if floating_ips:
             if is_partition:
-                ip_partition_list = map(lambda ip: {'ip-address-partition': ip}, floating_ips)
+                ip_partition_list = [{'ip-address-partition': ip} for ip in floating_ips]
                 vrid_floating_ips = {
                     'ip-address-part-cfg': ip_partition_list
                 }
             else:
-                ip_list = map(lambda ip: {'ip-address': ip}, floating_ips)
+                ip_list = [{'ip-address': ip} for ip in floating_ips]
                 vrid_floating_ips = {
                     'ip-address-cfg': ip_list
                 }

--- a/acos_client/v30/vrrpa/vrid.py
+++ b/acos_client/v30/vrrpa/vrid.py
@@ -38,25 +38,22 @@ class VRID(base.BaseV30):
         except acos_errors.NotFound:
             return False
 
-    def _build_params(self, vrid_val, threshold=None, disable=None, floating_ip=None,
+    def _build_params(self, vrid_val, threshold=None, disable=None, floating_ips=[],
                       is_partition=False):
         vrid = {'vrid-val': vrid_val}
-
-        vrid_floating_ip = None
-        if floating_ip:
+        vrid_floating_ips = None
+        if floating_ips:
             if is_partition:
-                vrid_floating_ip = {
-                    'ip-address-part-cfg': [{
-                        'ip-address-partition': floating_ip
-                    }]
+                ip_partition_list = map(lambda ip: {'ip-address-partition': ip}, floating_ips)
+                vrid_floating_ips = {
+                    'ip-address-part-cfg': ip_partition_list
                 }
             else:
-                vrid_floating_ip = {
-                    'ip-address-cfg': [{
-                        'ip-address': floating_ip
-                    }]
+                ip_list = map(lambda ip: {'ip-address': ip}, floating_ips)
+                vrid_floating_ips = {
+                    'ip-address-cfg': ip_list
                 }
-            vrid['floating-ip'] = vrid_floating_ip
+            vrid['floating-ip'] = vrid_floating_ips
 
         if threshold or disable:
             threshold = threshold if threshold in range(0, 256) else 1
@@ -65,19 +62,18 @@ class VRID(base.BaseV30):
                 'threshold': threshold,
                 'disable': disable
             }
-
             vrid['preempt-mode'] = preempt
 
         payload = {'vrid': vrid}
         return payload
 
-    def create(self, vrid_val, threshold=None, disable=None, floating_ip=None, is_partition=False):
+    def create(self, vrid_val, threshold=None, disable=None, floating_ips=[], is_partition=False):
         return self._post(self.base_url, self._build_params(vrid_val, threshold, disable,
-                                                            floating_ip, is_partition))
+                                                            floating_ips, is_partition))
 
-    def update(self, vrid_val, threshold=None, disable=None, floating_ip=None, is_partition=False):
+    def update(self, vrid_val, threshold=None, disable=None, floating_ips=[], is_partition=False):
         return self._put(self.base_url + str(vrid_val), self._build_params(vrid_val, threshold,
-                                                                           disable, floating_ip,
+                                                                           disable, floating_ips,
                                                                            is_partition))
 
     def delete(self, vrid_val):


### PR DESCRIPTION
## Issue Description
Added support for associating multiple floating IPs with a VRID (create / update)


## Jira Ticket
[STACK-1589](https://a10networks.atlassian.net/browse/STACK-1589)

## Technical approach
- Modified the `create` and `update` vrrpa vrid functions to take in a list of floating ips instead of a singular one
- Altered `_build_params` function to add each ip in the list to the payload

## Manual Tests
Requirement: Setup an Active-Standy VRRPA deployment

1. Issue a create command with a single IP ----> only one should be associated
2. Issue a create command with multiple IPs ----> all IPs should be added to the VRID
3. Issue an update command with same IPs as step 2 ----> no change
4. Issue an update command with one IP from step 2/3 removed ----> removed IP not in list (others should remain)