### PR TITLE
STACK-1559: Added support to allow templates to be used from the shared partition

### DIFF
--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -96,9 +96,15 @@ class ServiceGroup(base.BaseV30):
 
         if service_group_templates:
             service_group_templates = {k: v for k, v in service_group_templates.items() if v}
+
+            if service_group_templates.get('template-policy'):
+                params['service-group']['template-policy'] = service_group_templates['template-policy']
+            elif service_group_templates.get('template-policy-shared'):
+                params['service-group']['template-policy-shared'] = service_group_templates['template-policy-shared']
+                params['service-group']['shared-partition-policy-template'] = True
+
             params['service-group']['template-server'] = service_group_templates.get('template-server', None)
             params['service-group']['template-port'] = service_group_templates.get('template-port', None)
-            params['service-group']['template-policy'] = service_group_templates.get('template-policy', None)
 
         config_defaults = kwargs.get("config_defaults")
 

--- a/acos_client/v30/slb/template/templates.py
+++ b/acos_client/v30/slb/template/templates.py
@@ -1,4 +1,4 @@
-# Copyright 2015,  Tobit Raff,  A10 Networks.
+# Copyright 2020, A10 Networks.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -14,12 +14,12 @@
 
 from acos_client.v30 import base
 
+
 class BaseTemplate(base.BaseV30):
 
     def get(self, **kwargs):
-        return self._get(self.url_prefix , **kwargs)
+        return self._get(self.url_prefix, **kwargs)
 
 
 class Templates(BaseTemplate):
     url_prefix = '/slb/template/'
-   

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -106,7 +106,7 @@ class VirtualPort(base.BaseV30):
         }
         if virtual_port_templates:
             virtual_port_templates = {k: v for k, v in virtual_port_templates.items() if v}
- 
+
             if virtual_port_templates.get('template-virtual-port'):
                 params['port']['template-virtual-port'] = virtual_port_templates['template-virtual-port']
             elif virtual_port_templates.get('template-virtual-port-shared'):
@@ -122,9 +122,9 @@ class VirtualPort(base.BaseV30):
             else:
                 if virtual_port_templates.get('template-tcp'):
                     params['port']['template-tcp'] = virtual_port_templates['template-tcp']
-                elif virtual_port_templates.get('template-http-shared'):
+                elif virtual_port_templates.get('template-tcp-shared'):
                     params['port']['template-tcp-shared'] = virtual_port_templates['template-tcp-shared']
-                    params['port']['shared-partition-tcp'] = True 
+                    params['port']['shared-partition-tcp'] = True
 
             if virtual_port_templates.get('template-policy'):
                 params['port']['template-policy'] = virtual_port_templates['template-policy']
@@ -157,7 +157,11 @@ class VirtualPort(base.BaseV30):
         if server_ssl_tmpl:
             params['port']['template-server-ssl'] = server_ssl_tmpl
         if client_ssl_tmpl:
-            params['port']['template-client-ssl'] = client_ssl_tmpl
+            if client_ssl_tmpl.get('template-client-ssl'):
+                params['port']['template-client-ssl'] = virtual_port_templates['template-client-ssl']
+            elif virtual_port_templates.get('template-client-ssl-shared'):
+                params['port']['template-client-ssl-shared'] = virtual_port_templates['template-client-ssl-shared']
+                params['port']['shared-partition-client-ssl-template'] = True
 
         sampling_enable = kwargs.get('sampling_enable')
         if sampling_enable is not None:

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -157,11 +157,7 @@ class VirtualPort(base.BaseV30):
         if server_ssl_tmpl:
             params['port']['template-server-ssl'] = server_ssl_tmpl
         if client_ssl_tmpl:
-            if client_ssl_tmpl.get('template-client-ssl'):
-                params['port']['template-client-ssl'] = virtual_port_templates['template-client-ssl']
-            elif virtual_port_templates.get('template-client-ssl-shared'):
-                params['port']['template-client-ssl-shared'] = virtual_port_templates['template-client-ssl-shared']
-                params['port']['shared-partition-client-ssl-template'] = True
+            params['port']['template-client-ssl'] = client_ssl_tmpl
 
         sampling_enable = kwargs.get('sampling_enable')
         if sampling_enable is not None:


### PR DESCRIPTION
## Description
Added support for attaching templates from shared partition to virtual-port, service-group and server of a l3v partition.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1559

## Technical Approach
**For listener:**
- Added support for `template-http-shared` and `shared-partition-http-template` params to attach shared http templates  to a virtual-port.
- Added support for `template-tcp-shared` and `shared-partition-tcp` params to attach shared tcp templates  to a virtual-port.
- Added support for `template-policy-shared` and `shared-partition-policy-template` params to attach shared policy templates  to a virtual-port.
- Added support for `template-virtual-port-shared` and `shared-partition-virtual-port-template` params to attach shared virtual port templates  to a virtual-port.

**For pool:**
- Added support for `template-policy-shared` and `shared-partition-policy-template` params to attach shared policy templates  to a service-group.

## Related PR
https://github.com/a10networks/a10-octavia/pull/181