### PR TITLE
STACK-1612: Handled validations of loadbalancer description

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_virtual_server.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_server.py
@@ -54,6 +54,7 @@ class TestVirtualServer(unittest.TestCase):
                 'ip-address': '192.168.2.254',
                 'name': VSERVER_NAME,
                 'arp-disable': 0,
+                'description': None,
             }
         }
 
@@ -116,6 +117,7 @@ class TestVirtualServer(unittest.TestCase):
                 'ip-address': '192.168.2.254',
                 'name': VSERVER_NAME,
                 'arp-disable': 0,
+                'description': None,
             }
         }
 
@@ -175,6 +177,7 @@ class TestVirtualServer(unittest.TestCase):
                 'template-logging': 'template_lg',
                 'template-policy': 'template_pl',
                 'template-scaleout': 'template_sc',
+                'description': None,
             }
         }
 
@@ -249,6 +252,7 @@ class TestVirtualServer(unittest.TestCase):
                 'template-logging': 'template_lg',
                 'template-policy': None,
                 'template-scaleout': None,
+                'description': None,
             }
         }
 

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -49,8 +49,11 @@ class VirtualServer(base.BaseV30):
         else:
             params['virtual-server']['ip-address'] = ip_address
 
-        if description:
+        if description and len(description) > 1:
             params['virtual-server']['description'] = description
+        else:
+            params['virtual-server']['description'] = None
+
         if vrid:
             params['virtual-server']['vrid'] = int(vrid)
         if virtual_server_templates:

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -49,7 +49,7 @@ class VirtualServer(base.BaseV30):
         else:
             params['virtual-server']['ip-address'] = ip_address
 
-        if description and len(description) > 1:
+        if description:
             params['virtual-server']['description'] = description
         else:
             params['virtual-server']['description'] = None


### PR DESCRIPTION
## Description
- When we set loadbalancer description to "" or " ", then the description parameter should not get attached to it i.e it should set to be **None** for the loadbalancer instead of throwing `ACOSException: 1023459374 Input string exceeds permitted length`.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1612

## Related PR
https://github.com/a10networks/a10-octavia/pull/184

## Technical Approach
- Trimming the description given by user and then validating it.
- If description is "" or " ", then it is set to None

## Test Cases
- Given description as "", when an lb is updated with it, the description attaching to the lb is None.
- Given description as " ", when an lb is updated with it, the description attaching to the lb is None.
