### PR TITLE
[BUG][STACK-1647] Added default values for template related configurations

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_virtual_port.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_port.py
@@ -55,7 +55,11 @@ class TestVirtualPort(unittest.TestCase):
                 'name': 'test1_VPORT',
                 'port-number': 80,
                 'protocol': 'http',
-                'service-group': 'pool1'
+                'service-group': 'pool1',
+                'template-policy': None,
+                'template-tcp': None,
+                'template-virtual-port': None,
+                'template-http': None
             }
         }
 
@@ -93,7 +97,11 @@ class TestVirtualPort(unittest.TestCase):
                 'template-persist-cookie': 'test_c_pers_template',
                 'template-persist-source-ip': 'test_s_pers_template',
                 'udp_template': 'test_udp_template',
-                'use-rcv-hop-for-resp': 1
+                'use-rcv-hop-for-resp': 1,
+                'template-policy': None,
+                'template-tcp': None,
+                'template-virtual-port': None,
+                'template-http': None
             }
         }
 
@@ -157,7 +165,11 @@ class TestVirtualPort(unittest.TestCase):
                 "port-number": 80,
                 "template-persist-source-ip": None,
                 "template-persist-cookie": None,
-                "extended-stats": 1
+                "extended-stats": 1,
+                "template-virtual-port": None,
+                "template-policy": None,
+                "template-tcp": None,
+                "template-http": None
             }
         }
 
@@ -196,7 +208,9 @@ class TestVirtualPort(unittest.TestCase):
                     'template-persist-source-ip': 'test_s_pers_template',
                     'udp_template': 'test_udp_template',
                     'template-virtual-port': 'template_vp',
-                    'template-policy': 'template_pl'
+                    'template-policy': 'template_pl',
+                    'template-http': None,
+                    'template-tcp': None
                 }
             }
         else:
@@ -217,7 +231,9 @@ class TestVirtualPort(unittest.TestCase):
                     'udp_template': 'test_udp_template',
                     'template-virtual-port': 'template_vp',
                     'template-tcp': 'template_tcp',
-                    'template-policy': 'template_pl'
+                    'template-policy': 'template_pl',
+                    'template-http': None,
+                    'template-tcp': None
                 }
             }
 
@@ -271,7 +287,11 @@ class TestVirtualPort(unittest.TestCase):
                     'template-persist-cookie': 'test_c_pers_template',
                     'template-persist-source-ip': 'test_s_pers_template',
                     'udp_template': 'test_udp_template',
-                    'template-virtual-port': 'template_vp'
+                    'template-virtual-port': 'template_vp',
+                    'template-policy': None,
+                    'template-tcp': None,
+                    'template-http': None
+
                 }
             }
         else:
@@ -291,6 +311,7 @@ class TestVirtualPort(unittest.TestCase):
                     'template-persist-source-ip': 'test_s_pers_template',
                     'udp_template': 'test_udp_template',
                     'template-virtual-port': 'template_vp',
+                    'template-policy': None,
                     'template-tcp': None,
                     'template-policy': None,
                 }
@@ -347,6 +368,10 @@ class TestVirtualPort(unittest.TestCase):
                 'template-persist-source-ip': 'test_s_pers_template',
                 'udp_template': 'test_udp_template',
                 'use-rcv-hop-for-resp': 1,
+                'template-virtual-port': None,
+                'template-policy': None,
+                'template-tcp': None,
+                'template-http': None
             }
         }
 
@@ -403,7 +428,11 @@ class TestVirtualPort(unittest.TestCase):
                     'template-persist-cookie': 'test_c_pers_template',
                     'template-persist-source-ip': 'test_s_pers_template',
                     'udp_template': 'test_udp_template',
-                    'template-virtual-port': 'template_vp'
+                    'template-virtual-port': 'template_vp',
+                    'template-policy': None,
+                    'template-tcp': None,
+                    'template-http': None
+
                 }
             }
         else:
@@ -426,7 +455,11 @@ class TestVirtualPort(unittest.TestCase):
                     'template-persist-cookie': 'test_c_pers_template',
                     'template-persist-source-ip': 'test_s_pers_template',
                     'udp_template': 'test_udp_template',
-                    'template-virtual-port': 'template_vp'
+                    'template-virtual-port': 'template_vp',
+                    'template-policy': None,
+                    'template-tcp': None,
+                    'template-http': None
+
                 }
             }
         resp = self.client.slb.virtual_server.vport.update(

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -104,6 +104,10 @@ class VirtualPort(base.BaseV30):
             }, exclude=exclude_minimize
             )
         }
+        params['port']['template-virtual-port'] = None
+        params['port']['template-http'] = None
+        params['port']['template-tcp'] = None
+        params['port']['template-policy'] = None
         if virtual_port_templates:
             virtual_port_templates = {k: v for k, v in virtual_port_templates.items() if v}
 


### PR DESCRIPTION
## Highlights:

Added default values for template related configurations for resolving the issue occurring while setting listener without specifying templates in configuration file. 

## Jira Ticket:
https://a10networks.atlassian.net/browse/STACK-1647

## Manual Testing:

1. For L3V Partition:

Step1: Create a listener with attaching templates for TCP and HTTP protocol

![image](https://user-images.githubusercontent.com/41860430/94519789-cf139500-0248-11eb-8c19-1caed319e314.png)

Step 2: Set listener to remove templates for  TCP and HTTP protocol

![image](https://user-images.githubusercontent.com/41860430/94519946-126e0380-0249-11eb-9f47-cb4a3f5db4d9.png)

2. For Shared Partition

Step1: Create a listener with attaching templates for TCP and HTTP protocol

![image](https://user-images.githubusercontent.com/41860430/94520009-2e71a500-0249-11eb-902b-64354d0d984a.png)

Step 2: Set listener to remove templates for  TCP and HTTP protocol

![image](https://user-images.githubusercontent.com/41860430/94520130-59f48f80-0249-11eb-8ba9-4d9193bc5df7.png)



