### PR TITLE
[BUG][STACK-1651]:  Added default values for template related configurations related to pool and member

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_server.py
+++ b/acos_client/tests/unit/v30/test_slb_server.py
@@ -56,6 +56,7 @@ class TestServer(unittest.TestCase):
                 'health-check': None,
                 'host': '192.168.2.254',
                 'name': VSERVER_NAME,
+                'template-server': None,
             }
         }
 
@@ -186,6 +187,7 @@ class TestIPv6Server(unittest.TestCase):
                 'health-check': None,
                 'server-ipv6-addr': '2001:baad:deed:bead:daab:daad:cead:100e',
                 'name': VSERVER_NAME,
+                'template-server': None,
             }
         }
 

--- a/acos_client/tests/unit/v30/test_slb_service_group.py
+++ b/acos_client/tests/unit/v30/test_slb_service_group.py
@@ -112,7 +112,8 @@ class TestVirtualServer(unittest.TestCase):
                 'protocol': 'tcp',
                 'stateless-auto-switch': 0,
                 'template-server': 'template_sv',
-                'template-port': 'template_port'
+                'template-port': 'template_port',
+                'template-policy': None
             }
         }
 

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -38,6 +38,7 @@ class Server(base.BaseV30):
                 "health-check": kwargs.get("health_check")
             }
         }
+        params['server']['template-server'] = None
 
         if self._is_ipv6(ip_address):
             params['server']['server-ipv6-addr'] = ip_address

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -67,6 +67,9 @@ class ServiceGroup(base.BaseV30):
                 "protocol": protocol,
             })
         }
+        params['service-group']['template-policy'] = None
+        params['service-group']['template-server'] = None
+        params['service-group']['template-port'] = None
 
         # If we explicitly disable health checks, ensure it happens
         # Else, we implicitly disable health checks if not specified.


### PR DESCRIPTION
## Highlights:
Added default values for template related configurations for resolving the issue occurring while setting pool and member without specifying templates in configuration file.

## Jira Ticket:
https://a10networks.atlassian.net/browse/STACK-1651

## Manual Testing:
For Pool:
1. For L3V Partition:

Step1: Create a pool with attaching templates 
![image](https://user-images.githubusercontent.com/41860430/94781086-fc964500-03e6-11eb-9fbe-425f628cc39f.png)

Step 2: Set a pool to remove templates 
![image](https://user-images.githubusercontent.com/41860430/94781312-43843a80-03e7-11eb-9b5c-3ccfe74aeaab.png)

2. For Shared Partition

Step1: Create a pool with attaching templates

![image](https://user-images.githubusercontent.com/41860430/94779906-41b97780-03e5-11eb-802a-dbfc280af279.png)

Step 2: Set a pool to remove templates 

![image](https://user-images.githubusercontent.com/41860430/94779997-64e42700-03e5-11eb-890d-f369c7571258.png)

For Member:

1. For L3V Partition:

Step1: Create a member with attaching templates 
![image](https://user-images.githubusercontent.com/41860430/94782248-99a5ad80-03e8-11eb-8092-4ea1160bf598.png)

Step 2: Set a member to remove templates 
![image](https://user-images.githubusercontent.com/41860430/94782478-e8ebde00-03e8-11eb-93da-24c72158a038.png)

2. For Shared Partition

Step1: Create a member with attaching templates
![image](https://user-images.githubusercontent.com/41860430/94783432-492f4f80-03ea-11eb-86c2-5f37628358fa.png)


Step 2: Set a member to remove templates 
![image](https://user-images.githubusercontent.com/41860430/94783666-a3301500-03ea-11eb-8577-765d3f8025a6.png)

