### PR TITLE
 [BUG][STACK-1651]: Added default values for template related configurations related to pool and member

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_server.py
+++ b/acos_client/tests/unit/v30/test_slb_server.py
@@ -56,6 +56,7 @@ class TestServer(unittest.TestCase):
                 'health-check': None,
                 'host': '192.168.2.254',
                 'name': VSERVER_NAME,
+                'template-server': None,
             }
         }
 
@@ -186,6 +187,7 @@ class TestIPv6Server(unittest.TestCase):
                 'health-check': None,
                 'server-ipv6-addr': '2001:baad:deed:bead:daab:daad:cead:100e',
                 'name': VSERVER_NAME,
+                'template-server': None,
             }
         }
 

--- a/acos_client/tests/unit/v30/test_slb_service_group.py
+++ b/acos_client/tests/unit/v30/test_slb_service_group.py
@@ -112,7 +112,8 @@ class TestVirtualServer(unittest.TestCase):
                 'protocol': 'tcp',
                 'stateless-auto-switch': 0,
                 'template-server': 'template_sv',
-                'template-port': 'template_port'
+                'template-port': 'template_port',
+                'template-policy': None
             }
         }
 

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -38,6 +38,7 @@ class Server(base.BaseV30):
                 "health-check": kwargs.get("health_check")
             }
         }
+        params['server']['template-server'] = None
 
         if self._is_ipv6(ip_address):
             params['server']['server-ipv6-addr'] = ip_address

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -67,6 +67,9 @@ class ServiceGroup(base.BaseV30):
                 "protocol": protocol,
             })
         }
+        params['service-group']['template-policy'] = None
+        params['service-group']['template-server'] = None
+        params['service-group']['template-port'] = None
 
         # If we explicitly disable health checks, ensure it happens
         # Else, we implicitly disable health checks if not specified.


### PR DESCRIPTION
## Highlights:
- Added default values for template related configurations for resolving the issue occurring while setting pool and member without specifying templates in configuration file.
- As default values related to templates were removed during earlier code changes. Here adding them again.

## Jira Ticket:
https://a10networks.atlassian.net/browse/STACK-1651

## Manual Testing:
For Pool:

1. For L3V Partition:

Step1: Create a pool with attaching templates
![image](https://user-images.githubusercontent.com/41860430/95184561-297e9980-07e5-11eb-86de-a3891c697e26.png)

Step 2: Set a pool to remove templates
![image](https://user-images.githubusercontent.com/41860430/95184626-42874a80-07e5-11eb-8845-da09b1a5eea8.png)

2. For Shared Partition

Step1: Create a pool with attaching templates
![image](https://user-images.githubusercontent.com/41860430/95184709-62b70980-07e5-11eb-9570-fd1d789c15eb.png)

Step 2: Set a pool to remove templates
![image](https://user-images.githubusercontent.com/41860430/95184855-92661180-07e5-11eb-83cb-cf4209a6a2da.png)

For Member:

1. For L3V Partition:

Step1: Create a member with attaching templates
![image](https://user-images.githubusercontent.com/41860430/95185027-ce997200-07e5-11eb-9fc5-9d03e0064fea.png)

Step 2: Set a member to remove templates
![image](https://user-images.githubusercontent.com/41860430/95185133-f38de500-07e5-11eb-880b-f63b04f797b0.png)

2. For Shared Partition:

Step1: Create a member with attaching templates
![image](https://user-images.githubusercontent.com/41860430/95185289-233ced00-07e6-11eb-8acc-aac0adec45c0.png)

Step 2: Set a member to remove templates
![image](https://user-images.githubusercontent.com/41860430/95185375-45366f80-07e6-11eb-9bbf-f0b249ebe86a.png)
