### PR TITLE
[STACK 1647][STACK-1651] Add replace methods to address template overwrite needs

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_server.py
+++ b/acos_client/tests/unit/v30/test_slb_server.py
@@ -69,14 +69,6 @@ class TestServer(unittest.TestCase):
 
     @mock.patch('acos_client.v30.slb.server.Server.get')
     @responses.activate
-    def test_server_create_already_exists(self, mocked_get):
-        mocked_get.return_value = {"foo": "bar"}
-
-        with self.assertRaises(acos_errors.Exists):
-            self.client.slb.server.create('test', '192.168.2.254')
-
-    @mock.patch('acos_client.v30.slb.server.Server.get')
-    @responses.activate
     def test_server_create_with_template(self, mocked_get):
         mocked_get.side_effect = acos_errors.NotFound
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
@@ -174,7 +166,6 @@ class TestIPv6Server(unittest.TestCase):
     @mock.patch('acos_client.v30.slb.server.Server.get')
     @responses.activate
     def test_server_create(self, mocked_get):
-        mocked_get.side_effect = acos_errors.NotFound
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {'foo': 'bar'}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
@@ -199,16 +190,7 @@ class TestIPv6Server(unittest.TestCase):
 
     @mock.patch('acos_client.v30.slb.server.Server.get')
     @responses.activate
-    def test_server_create_already_exists(self, mocked_get):
-        mocked_get.return_value = {"foo": "bar"}
-
-        with self.assertRaises(acos_errors.Exists):
-            self.client.slb.server.create('test', '2001:baad:deed:bead:daab:daad:cead:100e')
-
-    @mock.patch('acos_client.v30.slb.server.Server.get')
-    @responses.activate
     def test_server_create_with_template(self, mocked_get):
-        mocked_get.side_effect = acos_errors.NotFound
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {'foo': 'bar'}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)

--- a/acos_client/tests/unit/v30/test_slb_server.py
+++ b/acos_client/tests/unit/v30/test_slb_server.py
@@ -17,9 +17,7 @@ from __future__ import unicode_literals
 
 try:
     import unittest
-    from unittest import mock
 except ImportError:
-    import mock
     import unittest2 as unittest
 
 from acos_client import client
@@ -41,10 +39,8 @@ class TestServer(unittest.TestCase):
     def setUp(self):
         self.client = client.Client(HOSTNAME, '30', 'fake_username', 'fake_password')
 
-    @mock.patch('acos_client.v30.slb.server.Server.get')
     @responses.activate
-    def test_server_create(self, mocked_get):
-        mocked_get.side_effect = acos_errors.NotFound
+    def test_server_create(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {'foo': 'bar'}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
@@ -67,10 +63,8 @@ class TestServer(unittest.TestCase):
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
-    @mock.patch('acos_client.v30.slb.server.Server.get')
     @responses.activate
-    def test_server_create_with_template(self, mocked_get):
-        mocked_get.side_effect = acos_errors.NotFound
+    def test_server_create_with_template(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {'foo': 'bar'}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
@@ -94,6 +88,60 @@ class TestServer(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @responses.activate
+    def test_server_update_with_template(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {'foo': 'bar'}
+        responses.add(responses.POST, OBJECT_URL, json=json_response, status=200)
+        params = {
+            'server': {
+                'action': 'enable',
+                'conn-limit': None,
+                'conn-resume': None,
+                'host': '192.168.2.254',
+                'name': VSERVER_NAME,
+                'health-check': None,
+                'template-server': 'test-template-server'
+            }
+        }
+        templates = {
+            "template-server": "test-template-server"
+        }
+        resp = self.client.slb.server.update('test', '192.168.2.254', server_templates=templates)
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @responses.activate
+    def test_server_replace_with_template(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {'foo': 'bar'}
+        responses.add(responses.PUT, OBJECT_URL, json=json_response, status=200)
+        params = {
+            'server': {
+                'action': 'enable',
+                'conn-limit': None,
+                'conn-resume': None,
+                'host': '192.168.2.254',
+                'name': VSERVER_NAME,
+                'health-check': None,
+                'template-server': 'test-template-server'
+            }
+        }
+        templates = {
+            "template-server": "test-template-server"
+        }
+        resp = self.client.slb.server.replace('test', '192.168.2.254', server_templates=templates)
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.PUT)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
     @responses.activate
@@ -163,9 +211,8 @@ class TestIPv6Server(unittest.TestCase):
     def setUp(self):
         self.client = client.Client(HOSTNAME, '30', 'fake_username', 'fake_password')
 
-    @mock.patch('acos_client.v30.slb.server.Server.get')
     @responses.activate
-    def test_server_create(self, mocked_get):
+    def test_server_create(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {'foo': 'bar'}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
@@ -188,9 +235,8 @@ class TestIPv6Server(unittest.TestCase):
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
-    @mock.patch('acos_client.v30.slb.server.Server.get')
     @responses.activate
-    def test_server_create_with_template(self, mocked_get):
+    def test_server_create_with_template(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {'foo': 'bar'}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
@@ -214,6 +260,60 @@ class TestIPv6Server(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @responses.activate
+    def test_server_update_with_template(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {'foo': 'bar'}
+        responses.add(responses.POST, OBJECT_URL, json=json_response, status=200)
+        params = {
+            'server': {
+                'action': 'enable',
+                'conn-limit': None,
+                'conn-resume': None,
+                'host': '192.168.2.254',
+                'name': VSERVER_NAME,
+                'health-check': None,
+                'template-server': 'test-template-server'
+            }
+        }
+        templates = {
+            "template-server": "test-template-server"
+        }
+        resp = self.client.slb.server.update('test', '192.168.2.254', server_templates=templates)
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @responses.activate
+    def test_server_replace_with_template(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {'foo': 'bar'}
+        responses.add(responses.PUT, OBJECT_URL, json=json_response, status=200)
+        params = {
+            'server': {
+                'action': 'enable',
+                'conn-limit': None,
+                'conn-resume': None,
+                'host': '192.168.2.254',
+                'name': VSERVER_NAME,
+                'health-check': None,
+                'template-server': 'test-template-server'
+            }
+        }
+        templates = {
+            "template-server": "test-template-server"
+        }
+        resp = self.client.slb.server.replace('test', '192.168.2.254', server_templates=templates)
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.PUT)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
     @responses.activate

--- a/acos_client/tests/unit/v30/test_slb_service_group.py
+++ b/acos_client/tests/unit/v30/test_slb_service_group.py
@@ -144,6 +144,19 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
 
     @responses.activate
+    def test_server_group_replace(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.PUT, OBJECT_URL, json=json_response, status=200)
+
+        resp = self.client.slb.service_group.replace('test1', protocl='tcp')
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.PUT)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+
+    @responses.activate
     def test_server_group_delete(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {"foo": "bar"}

--- a/acos_client/tests/unit/v30/test_slb_virtual_port.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_port.py
@@ -457,6 +457,142 @@ class TestVirtualPort(unittest.TestCase):
         self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
+    @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
+    @responses.activate
+    def test_virtual_port_replace_with_params(self, mocked_get):
+        mocked_get.return_value = {"foo": "bar"}
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.PUT, OBJECT_URL, json=json_response, status=200)
+        params = {
+            'port':
+            {
+                'auto': 1,
+                'extended-stats': 1,
+                'name': 'test1_VPORT',
+                'ipinip': 1,
+                'no-dest-nat': 1,
+                'pool': 'test_nat_pool',
+                'port-number': 80,
+                'protocol': 'http',
+                'service-group': 'pool1',
+                'ha-conn-mirror': 1,
+                'conn-limit': 50000,
+                'tcp_template': 'test_tcp_template',
+                'template-persist-cookie': 'test_c_pers_template',
+                'template-persist-source-ip': 'test_s_pers_template',
+                'udp_template': 'test_udp_template',
+                'use-rcv-hop-for-resp': 1,
+            }
+        }
+
+        resp = self.client.slb.virtual_server.vport.replace(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.HTTP,
+            port='80',
+            service_group_name='pool1',
+            s_pers_name="test_s_pers_template",
+            c_pers_name="test_c_pers_template",
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            ha_conn_mirror=1,
+            no_dest_nat=1,
+            conn_limit=50000,
+            source_nat_pool="test_nat_pool",
+            tcp_template="test_tcp_template",
+            udp_template="test_udp_template",
+            use_rcv_hop=True,
+        )
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.PUT)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
+    @responses.activate
+    def test_virtual_port_replace_with_templates(self, mocked_get):
+        mocked_get.return_value = {"foo": "bar"}
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.PUT, OBJECT_URL, json=json_response, status=200)
+        protocol = self.client.slb.virtual_server.vport.HTTP
+        if protocol.lower() == 'http':
+            params = {
+                'port':
+                {
+                    'auto': 1,
+                    'extended-stats': 1,
+                    'name': 'test1_VPORT',
+                    'ipinip': 1,
+                    'no-dest-nat': 0,
+                    'use-rcv-hop-for-resp': 0,
+                    'pool': 'test_nat_pool',
+                    'port-number': 80,
+                    'protocol': 'http',
+                    'service-group': 'pool1',
+                    'ha-conn-mirror': 1,
+                    'conn-limit': 50000,
+                    'tcp_template': 'test_tcp_template',
+                    'template-persist-cookie': 'test_c_pers_template',
+                    'template-persist-source-ip': 'test_s_pers_template',
+                    'udp_template': 'test_udp_template',
+                    'template-virtual-port': 'template_vp'
+                }
+            }
+        else:
+            params = {
+                'port':
+                {
+                    'auto': 1,
+                    'extended-stats': 1,
+                    'name': 'test1_VPORT',
+                    'ipinip': 1,
+                    'no-dest-nat': 0,
+                    'use-rcv-hop-for-resp': 0,
+                    'pool': 'test_nat_pool',
+                    'port-number': 80,
+                    'protocol': 'http',
+                    'service-group': 'pool1',
+                    'ha-conn-mirror': 1,
+                    'conn-limit': 50000,
+                    'tcp_template': 'test_tcp_template',
+                    'template-persist-cookie': 'test_c_pers_template',
+                    'template-persist-source-ip': 'test_s_pers_template',
+                    'udp_template': 'test_udp_template',
+                    'template-virtual-port': 'template_vp'
+                }
+            }
+        resp = self.client.slb.virtual_server.vport.replace(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.HTTP,
+            port='80',
+            service_group_name='pool1',
+            s_pers_name="test_s_pers_template",
+            c_pers_name="test_c_pers_template",
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            ha_conn_mirror=1,
+            no_dest_nat=0,
+            conn_limit=50000,
+            source_nat_pool="test_nat_pool",
+            tcp_template="test_tcp_template",
+            udp_template="test_udp_template",
+            virtual_port_templates={
+                'template-virtual-port': 'template_vp'
+            },
+            use_rcv_hop=False,
+        )
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.PUT)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
     @responses.activate
     def test_virtual_port_delete(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})

--- a/acos_client/tests/unit/v30/test_slb_virtual_port.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_port.py
@@ -35,19 +35,18 @@ VSERVER_NAME = 'test'
 CREATE_URL = '{}/slb/virtual-server/{}/port/'.format(BASE_URL, VSERVER_NAME)
 OBJECT_URL = '{}/slb/virtual-server/{}/port/80+http'.format(BASE_URL, VSERVER_NAME)
 ALL_URL = '{}/slb/virtual-server/{}/port/'.format(BASE_URL, VSERVER_NAME)
+OK_RESP = {'response': {'status': 'OK'}}
 
 
 class TestVirtualPort(unittest.TestCase):
 
     def setUp(self):
         self.client = client.Client(HOSTNAME, '30', 'fake_username', 'fake_password')
-        self.maxDiff = None
 
     @responses.activate
     def test_virtual_port_create_no_params(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
-        json_response = {'response': {'status': 'OK'}}
-        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        responses.add(responses.POST, CREATE_URL, json=OK_RESP, status=200)
         params = {
             'port':
             {
@@ -64,7 +63,7 @@ class TestVirtualPort(unittest.TestCase):
             service_group_name='pool1'
         )
 
-        self.assertEqual(resp, json_response)
+        self.assertEqual(resp, OK_RESP)
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
@@ -73,8 +72,7 @@ class TestVirtualPort(unittest.TestCase):
     @responses.activate
     def test_virtual_port_create_with_params(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
-        json_response = {'response': {'status': 'OK'}}
-        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        responses.add(responses.POST, CREATE_URL, json=OK_RESP, status=200)
         params = {
             'port':
             {
@@ -117,7 +115,7 @@ class TestVirtualPort(unittest.TestCase):
             use_rcv_hop=True,
         )
 
-        self.assertEqual(resp, json_response)
+        self.assertEqual(resp, OK_RESP)
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
@@ -144,8 +142,8 @@ class TestVirtualPort(unittest.TestCase):
     @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
     @responses.activate
     def test_virtual_port_update_no_params(self, mocked_get):
-        mocked_get.return_value = {"foo": "bar"}
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        mocked_get.return_value = {"foo": "bar"}
         json_response = {"foo": "bar"}
         responses.add(responses.POST, OBJECT_URL, json=json_response, status=200)
         params = {
@@ -176,8 +174,7 @@ class TestVirtualPort(unittest.TestCase):
     @responses.activate
     def test_virtual_port_create_with_templates(self, mocked_get):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
-        json_response = {'response': {'status': 'OK'}}
-        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        responses.add(responses.POST, CREATE_URL, json=OK_RESP, status=200)
         protocol = self.client.slb.virtual_server.vport.HTTP
         if protocol.lower() == 'http':
             params = {
@@ -242,7 +239,7 @@ class TestVirtualPort(unittest.TestCase):
             },
         )
 
-        self.assertEqual(resp, json_response)
+        self.assertEqual(resp, OK_RESP)
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
@@ -252,8 +249,7 @@ class TestVirtualPort(unittest.TestCase):
     @responses.activate
     def test_virtual_port_create_with_partial_templates(self, mocked_get):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
-        json_response = {'response': {'status': 'OK'}}
-        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        responses.add(responses.POST, CREATE_URL, json=OK_RESP, status=200)
         protocol = self.client.slb.virtual_server.vport.HTTP
         if protocol.lower() == 'http':
             params = {
@@ -315,7 +311,7 @@ class TestVirtualPort(unittest.TestCase):
             },
         )
 
-        self.assertEqual(resp, json_response)
+        self.assertEqual(resp, OK_RESP)
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
@@ -324,8 +320,8 @@ class TestVirtualPort(unittest.TestCase):
     @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
     @responses.activate
     def test_virtual_port_update_with_params(self, mocked_get):
-        mocked_get.return_value = {"foo": "bar"}
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        mocked_get.return_value = {"foo": "bar"}
         json_response = {"foo": "bar"}
         responses.add(responses.POST, OBJECT_URL, json=json_response, status=200)
         params = {
@@ -378,8 +374,8 @@ class TestVirtualPort(unittest.TestCase):
     @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
     @responses.activate
     def test_virtual_port_update_with_templates(self, mocked_get):
-        mocked_get.return_value = {"foo": "bar"}
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        mocked_get.return_value = {"foo": "bar"}
         json_response = {"foo": "bar"}
         responses.add(responses.POST, OBJECT_URL, json=json_response, status=200)
         protocol = self.client.slb.virtual_server.vport.HTTP
@@ -460,8 +456,8 @@ class TestVirtualPort(unittest.TestCase):
     @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
     @responses.activate
     def test_virtual_port_replace_with_params(self, mocked_get):
-        mocked_get.return_value = {"foo": "bar"}
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        mocked_get.return_value = {"foo": "bar"}
         json_response = {"foo": "bar"}
         responses.add(responses.PUT, OBJECT_URL, json=json_response, status=200)
         params = {
@@ -514,8 +510,8 @@ class TestVirtualPort(unittest.TestCase):
     @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
     @responses.activate
     def test_virtual_port_replace_with_templates(self, mocked_get):
-        mocked_get.return_value = {"foo": "bar"}
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        mocked_get.return_value = {"foo": "bar"}
         json_response = {"foo": "bar"}
         responses.add(responses.PUT, OBJECT_URL, json=json_response, status=200)
         protocol = self.client.slb.virtual_server.vport.HTTP
@@ -596,16 +592,13 @@ class TestVirtualPort(unittest.TestCase):
     @responses.activate
     def test_virtual_port_delete(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
-        json_response = {
-            'response': {'status': 'OK'}
-        }
-        responses.add(responses.DELETE, OBJECT_URL, json=json_response, status=200)
+        responses.add(responses.DELETE, OBJECT_URL, json=OK_RESP, status=200)
 
         resp = self.client.slb.virtual_server.vport.delete(
             VSERVER_NAME, 'test1_VPORT', self.client.slb.virtual_server.vport.HTTP, '80'
         )
 
-        self.assertEqual(resp, json_response)
+        self.assertEqual(resp, OK_RESP)
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.DELETE)
         self.assertEqual(responses.calls[1].request.url, OBJECT_URL)

--- a/acos_client/tests/unit/v30/test_slb_virtual_server.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_server.py
@@ -14,6 +14,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import json
+import responses
+
 try:
     import unittest
     from unittest import mock
@@ -23,8 +26,6 @@ except ImportError:
 
 from acos_client import client
 import acos_client.errors as acos_errors
-import json
-import responses
 
 
 HOSTNAME = 'fake_a10'
@@ -42,10 +43,8 @@ class TestVirtualServer(unittest.TestCase):
     def setUp(self):
         self.client = client.Client(HOSTNAME, '30', 'fake_username', 'fake_password')
 
-    @mock.patch('acos_client.v30.slb.virtual_server.VirtualServer.get')
     @responses.activate
-    def test_virtual_server_create_no_params(self, mocked_get):
-        mocked_get.side_effect = acos_errors.NotFound
+    def test_virtual_server_create_no_params(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {"foo": "bar"}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
@@ -66,10 +65,8 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
-    @mock.patch('acos_client.v30.slb.virtual_server.VirtualServer.get')
     @responses.activate
-    def test_virtual_server_create_with_params(self, mocked_get):
-        mocked_get.side_effect = acos_errors.NotFound
+    def test_virtual_server_create_with_params(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {"foo": "bar"}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
@@ -98,14 +95,6 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
-
-    @mock.patch('acos_client.v30.slb.virtual_server.VirtualServer.get')
-    @responses.activate
-    def test_virtual_server_create_already_exists(self, mocked_get):
-        mocked_get.return_value = {"foo": "bar"}
-
-        with self.assertRaises(acos_errors.Exists):
-            self.client.slb.virtual_server.create('test', '192.168.2.254')
 
     @responses.activate
     def test_virtual_server_update_no_params(self):
@@ -151,7 +140,7 @@ class TestVirtualServer(unittest.TestCase):
             arp_disable=1,
             description='test_description',
             vrid=1,
-            template_virtual_server='TEST_VIP_TEMPLATE',
+            template_virtual_server='TEST_VIP_TEMPLATE'
         )
 
         self.assertEqual(resp, json_response)

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -112,12 +112,7 @@ class ServiceGroup(base.BaseV30):
             for k, v in six.iteritems(config_defaults):
                 params['service-group'][k] = v
 
-        if not update:
-            name = ''
-        else:
-            if 'protocol' in params['service-group']:
-                del params['service-group']['protocol']
-        return self._post(self.url_prefix + name, params, **kwargs)
+        return params, kwargs
 
     def all(self, *args, **kwargs):
         return self._get(self.url_prefix, **kwargs)
@@ -136,7 +131,9 @@ class ServiceGroup(base.BaseV30):
         else:
             raise acos_errors.Exists
 
-        return self._set(name, protocol, lb_method, service_group_templates, **kwargs)
+        params, kwargs = self._set(name, protocol=protocol, lb_method=lb_method,
+                                   service_group_templates=service_group_templates, **kwargs)
+        return self._post(self.url_prefix, params, **kwargs)
 
     def delete(self, name):
         return self._delete(self.url_prefix + name)
@@ -152,5 +149,12 @@ class ServiceGroup(base.BaseV30):
 
     def update(self, name, protocol=None, lb_method=None, health_monitor=None,
                service_group_templates=None, **kwargs):
-        return self._set(name, protocol, lb_method, hm_name=health_monitor,
-                         service_group_templates=service_group_templates, update=True, **kwargs)
+        params, kwargs = self._set(name, protocol=None, lb_method=lb_method, hm_name=health_monitor,
+                                   service_group_templates=service_group_templates, **kwargs)
+        return self._post(self.url_prefix + name, params, **kwargs)
+
+    def replace(self, name, protocol=None, lb_method=None, health_monitor=None,
+                service_group_templates=None, **kwargs):
+        params, kwargs = self._set(name, protocol=protocol, lb_method=lb_method, hm_name=health_monitor,
+                                   service_group_templates=service_group_templates, **kwargs)
+        return self._put(self.url_prefix + name, params, **kwargs)

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -112,7 +112,7 @@ class ServiceGroup(base.BaseV30):
             for k, v in six.iteritems(config_defaults):
                 params['service-group'][k] = v
 
-        return params, kwargs
+        return params
 
     def all(self, *args, **kwargs):
         return self._get(self.url_prefix, **kwargs)
@@ -131,8 +131,8 @@ class ServiceGroup(base.BaseV30):
         else:
             raise acos_errors.Exists
 
-        params, kwargs = self._set(name, protocol=protocol, lb_method=lb_method,
-                                   service_group_templates=service_group_templates, **kwargs)
+        params = self._set(name, protocol=protocol, lb_method=lb_method,
+                           service_group_templates=service_group_templates, **kwargs)
         return self._post(self.url_prefix, params, **kwargs)
 
     def delete(self, name):
@@ -149,12 +149,12 @@ class ServiceGroup(base.BaseV30):
 
     def update(self, name, protocol=None, lb_method=None, health_monitor=None,
                service_group_templates=None, **kwargs):
-        params, kwargs = self._set(name, protocol=None, lb_method=lb_method, hm_name=health_monitor,
-                                   service_group_templates=service_group_templates, **kwargs)
+        params = self._set(name, protocol=None, lb_method=lb_method, hm_name=health_monitor,
+                           service_group_templates=service_group_templates, **kwargs)
         return self._post(self.url_prefix + name, params, **kwargs)
 
     def replace(self, name, protocol=None, lb_method=None, health_monitor=None,
                 service_group_templates=None, **kwargs):
-        params, kwargs = self._set(name, protocol=protocol, lb_method=lb_method, hm_name=health_monitor,
-                                   service_group_templates=service_group_templates, **kwargs)
+        params = self._set(name, protocol=protocol, lb_method=lb_method, hm_name=health_monitor,
+                           service_group_templates=service_group_templates, **kwargs)
         return self._put(self.url_prefix + name, params, **kwargs)

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -180,8 +180,7 @@ class VirtualPort(base.BaseV30):
             url += self.url_port_tmpl.format(
                 port_number=port, protocol=protocol
             )
-
-        return self._post(url, params, **kwargs)
+        return url, params, kwargs
 
     def create(
         self,
@@ -206,7 +205,7 @@ class VirtualPort(base.BaseV30):
         **kwargs
     ):
 
-        return self._set(
+        url, params, kwargs = self._set(
             virtual_server_name,
             name,
             protocol,
@@ -228,7 +227,9 @@ class VirtualPort(base.BaseV30):
             **kwargs
         )
 
-    def update(
+        return self._post(url, params, **kwargs)
+
+    def _update(
         self,
         virtual_server_name,
         name,
@@ -250,6 +251,7 @@ class VirtualPort(base.BaseV30):
         udp_template=None,
         **kwargs
     ):
+
         vp = self.get(virtual_server_name, name, protocol, port)
         if vp is None:
             raise ae.NotFound()
@@ -257,7 +259,7 @@ class VirtualPort(base.BaseV30):
         exclude = ['template-persist-source-ip', 'template-persist-cookie']
 
         try:
-            return self._set(
+            url, params, kwargs = self._set(
                 virtual_server_name,
                 name,
                 protocol,
@@ -281,7 +283,7 @@ class VirtualPort(base.BaseV30):
                 **kwargs
             )
         except ae.AxapiJsonFormatError:
-            return self._set(
+            url, params, kwargs = self._set(
                 virtual_server_name,
                 name,
                 protocol,
@@ -304,6 +306,97 @@ class VirtualPort(base.BaseV30):
                 update=True,
                 **kwargs
             )
+        return url, params, kwargs
+
+    def update(
+        self,
+        virtual_server_name,
+        name,
+        protocol,
+        port,
+        service_group_name,
+        s_pers_name=None,
+        c_pers_name=None,
+        status=1,
+        autosnat=None,
+        ipinip=None,
+        no_dest_nat=None,
+        source_nat_pool=None,
+        ha_conn_mirror=None,
+        use_rcv_hop=None,
+        conn_limit=None,
+        virtual_port_templates=None,
+        tcp_template=None,
+        udp_template=None,
+        **kwargs
+    ):
+
+        url, params, kwargs = self._update(
+            virtual_server_name,
+            name,
+            protocol,
+            port,
+            service_group_name,
+            s_pers_name=s_pers_name,
+            c_pers_name=c_pers_name,
+            status=status,
+            autosnat=autosnat,
+            ipinip=ipinip,
+            no_dest_nat=no_dest_nat,
+            source_nat_pool=source_nat_pool,
+            ha_conn_mirror=ha_conn_mirror,
+            use_rcv_hop=use_rcv_hop,
+            conn_limit=conn_limit,
+            virtual_port_templates=virtual_port_templates,
+            tcp_template=tcp_template,
+            udp_template=udp_template,
+            **kwargs)
+        return self._post(url, params, **kwargs)
+
+    def replace(
+        self,
+        virtual_server_name,
+        name,
+        protocol,
+        port,
+        service_group_name,
+        s_pers_name=None,
+        c_pers_name=None,
+        status=1,
+        autosnat=None,
+        ipinip=None,
+        no_dest_nat=None,
+        source_nat_pool=None,
+        ha_conn_mirror=None,
+        use_rcv_hop=None,
+        conn_limit=None,
+        virtual_port_templates=None,
+        tcp_template=None,
+        udp_template=None,
+        **kwargs
+    ):
+
+        url, params, kwargs = self._update(
+            virtual_server_name,
+            name,
+            protocol,
+            port,
+            service_group_name,
+            s_pers_name=s_pers_name,
+            c_pers_name=c_pers_name,
+            status=status,
+            autosnat=autosnat,
+            ipinip=ipinip,
+            no_dest_nat=no_dest_nat,
+            source_nat_pool=source_nat_pool,
+            ha_conn_mirror=ha_conn_mirror,
+            use_rcv_hop=use_rcv_hop,
+            conn_limit=conn_limit,
+            virtual_port_templates=virtual_port_templates,
+            tcp_template=tcp_template,
+            udp_template=udp_template,
+            **kwargs)
+        return self._put(url, params, **kwargs)
 
     def delete(self, virtual_server_name, name, protocol, port):
         url = self.url_server_tmpl.format(name=virtual_server_name)

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -15,8 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import six
 
-
-from acos_client import errors as acos_errors
 from acos_client.v30 import base
 from acos_client.v30.slb.virtual_port import VirtualPort
 
@@ -35,7 +33,7 @@ class VirtualServer(base.BaseV30):
         return self._get(self.url_prefix + name)
 
     def _set(self, name, ip_address=None, arp_disable=False, description=None, vrid=None,
-             virtual_server_templates=None, template_virtual_server=None, update=False, **kwargs):
+             virtual_server_templates=None, template_virtual_server=None, **kwargs):
         params = {
             "virtual-server": self.minimal_dict({
                 "name": name,
@@ -73,26 +71,25 @@ class VirtualServer(base.BaseV30):
             for k, v in six.iteritems(config_defaults):
                 params['virtual-server'][k] = v
 
-        if not update:
-            name = ''
-        return self._post(self.url_prefix + name, params, **kwargs)
+        return params
 
     def create(self, name, ip_address, arp_disable=False, description=None, vrid=None,
                virtual_server_templates=None, template_virtual_server=None, **kwargs):
-        try:
-            self.get(name)
-        except acos_errors.NotFound:
-            pass
-        else:
-            raise acos_errors.Exists
-
-        return self._set(name, ip_address, arp_disable, description, vrid, virtual_server_templates,
-                         template_virtual_server, **kwargs)
+        params = self._set(name, ip_address, arp_disable, description, vrid, virtual_server_templates,
+                           template_virtual_server, **kwargs)
+        return self._post(self.url_prefix, params, **kwargs)
 
     def update(self, name, ip_address=None, arp_disable=False, description=None, vrid=None,
                virtual_server_templates=None, template_virtual_server=None, **kwargs):
-        return self._set(name, ip_address, arp_disable, description, vrid, virtual_server_templates,
-                         template_virtual_server, update=True, **kwargs)
+        params = self._set(name, ip_address, arp_disable, description, vrid, virtual_server_templates,
+                           template_virtual_server, **kwargs)
+        return self._post(self.url_prefix + name, params, **kwargs)
+
+    def replace(self, name, ip_address=None, arp_disable=False, description=None, vrid=None,
+                virtual_server_templates=None, template_virtual_server=None, **kwargs):
+        params = self._set(name, ip_address, arp_disable, description, vrid, virtual_server_templates,
+                           template_virtual_server, **kwargs)
+        return self._put(self.url_prefix + name, params, **kwargs)
 
     def delete(self, name):
         return self._delete(self.url_prefix + name)


### PR DESCRIPTION
## Description

For support of the a10-octavia driver, replace methods (resolving to a PUT call) are required for a number of endpoints surrounding the slb. This way changes in the configuration file can be reflected when updates occur allowing templates to be dissociated. 

## Jira Ticket
[STACK-1647](https://a10networks.atlassian.net/browse/STACK-1647)
[STACK-1651](https://a10networks.atlassian.net/browse/STACK-1651)

## Links
[PR 120 in a10-octavia](https://github.com/a10networks/a10-octavia/pull/210)


## Technical Approach
- Added replace methods which use the PUT request to fully replace the object.
- Refactored set methods to make allow them to be used with replace as well
- Altered the member tests so that they use the responses mock library to be sure PUT was called with proper params
- Removed get requests from create methods. (This was included due to issues in acos 4.1.1 and we are way beyond that version)

## Test Cases
- Successful member create, update, replace, and delete cases surrounding enable/disable
- Duplicated virtual port update tests, but with replace call used instead
- Duplicated service group update tests, but with replace call used instead
- Duplicated member update tests, but with replace call used instead
- Duplicated server relate template tests, but with update call used instead
- Duplicated server create template tests, but with replace call used instead

## Manual Testing

#### Virtual Server
Pre-req: Policy template

1. Create virtual server with policy template
2. Call replace method without specifying policy template

Expected result: Policy template is removed

#### Virtual Port
Pre-req: Create virtual server, http template

1. Create virtual port with http template
2. Call replace method without specifying http template

Expected result: Server template is removed

#### Service Group
Pre-req: Create virtual server, virtual port, policy template

1. Create service group with policy template
2. Call replace method without specifying policy template

Expected result: Policy template is removed

#### Member
Pre-req: Create virtual server, virtual port, service group, member template

1. Create member
3. Call replace with member template unspecified

Expected result: Member template is removed

#### Server
Pre-req: Server template

1. Create server
2. Call replace with server template without specifying server template

Expected result: Server template is removed
