### PR TITLE
[STACK-1703][STACK-1699] Replace methods cause overwrite of connected objects

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_service_group.py
+++ b/acos_client/tests/unit/v30/test_slb_service_group.py
@@ -16,9 +16,7 @@ from __future__ import unicode_literals
 
 try:
     import unittest
-    from unittest import mock
 except ImportError:
-    import mock
     import unittest2 as unittest
 
 from acos_client import client
@@ -40,10 +38,8 @@ class TestVirtualServer(unittest.TestCase):
     def setUp(self):
         self.client = client.Client(HOSTNAME, '30', 'fake_username', 'fake_password')
 
-    @mock.patch('acos_client.v30.slb.service_group.ServiceGroup.get')
     @responses.activate
-    def test_server_group_create(self, mocked_get):
-        mocked_get.side_effect = acos_errors.NotFound
+    def test_server_group_create(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {"foo": "bar"}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
@@ -56,10 +52,8 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
 
-    @mock.patch('acos_client.v30.slb.service_group.ServiceGroup.get')
     @responses.activate
-    def test_server_group_create_with_templates(self, mocked_get):
-        mocked_get.side_effect = acos_errors.NotFound
+    def test_server_group_create_with_templates(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {"foo": "bar"}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
@@ -89,10 +83,8 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
-    @mock.patch('acos_client.v30.slb.service_group.ServiceGroup.get')
     @responses.activate
-    def test_server_group_create_with_partial_templates(self, mocked_get):
-        mocked_get.side_effect = acos_errors.NotFound
+    def test_server_group_create_with_partial_templates(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {"foo": "bar"}
         responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
@@ -121,14 +113,6 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
-
-    @mock.patch('acos_client.v30.slb.service_group.ServiceGroup.get')
-    @responses.activate
-    def test_server_group_create_already_exists(self, mocked_get):
-        mocked_get.return_value = {"foo": "bar"}
-
-        with self.assertRaises(acos_errors.Exists):
-            self.client.slb.service_group.create('test1')
 
     @responses.activate
     def test_server_group_update(self):

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -15,8 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import six
 
-
-from acos_client import errors as acos_errors
 from acos_client.v30 import base
 from acos_client.v30.slb.member import Member
 
@@ -54,7 +52,7 @@ class ServiceGroup(base.BaseV30):
     UDP = 'udp'
 
     def _set(self, name, protocol=None, lb_method=None, service_group_templates=None,
-             hm_name=None, update=False, **kwargs):
+             hm_name=None, mem_list=None, **kwargs):
 
         # Normalize "" -> None for json
         hm_name = hm_name or None
@@ -65,6 +63,7 @@ class ServiceGroup(base.BaseV30):
             "service-group": self.minimal_dict({
                 "name": name,
                 "protocol": protocol,
+                "member-list": mem_list
             })
         }
 
@@ -123,16 +122,11 @@ class ServiceGroup(base.BaseV30):
     def all_oper(self, *args, **kwargs):
         return self._get(self.url_prefix + "oper", **kwargs)
 
-    def create(self, name, protocol=TCP, lb_method=ROUND_ROBIN, service_group_templates=None, **kwargs):
-        try:
-            self.get(name)
-        except acos_errors.NotFound:
-            pass
-        else:
-            raise acos_errors.Exists
-
+    def create(self, name, protocol=TCP, lb_method=ROUND_ROBIN, service_group_templates=None,
+               mem_list=None, hm_name=None, **kwargs):
         params = self._set(name, protocol=protocol, lb_method=lb_method,
-                           service_group_templates=service_group_templates, **kwargs)
+                           service_group_templates=service_group_templates,
+                           mem_list=mem_list, hm_name=hm_name, **kwargs)
         return self._post(self.url_prefix, params, **kwargs)
 
     def delete(self, name):
@@ -148,13 +142,15 @@ class ServiceGroup(base.BaseV30):
         return self._get(self.url_prefix + name + "/stats", **kwargs)
 
     def update(self, name, protocol=None, lb_method=None, health_monitor=None,
-               service_group_templates=None, **kwargs):
-        params = self._set(name, protocol=None, lb_method=lb_method, hm_name=health_monitor,
-                           service_group_templates=service_group_templates, **kwargs)
+               service_group_templates=None, mem_list=None, hm_name=None, **kwargs):
+        params = self._set(name, protocol=None, lb_method=lb_method, hm_name=hm_name,
+                           service_group_templates=service_group_templates,
+                           mem_list=mem_list, **kwargs)
         return self._post(self.url_prefix + name, params, **kwargs)
 
     def replace(self, name, protocol=None, lb_method=None, health_monitor=None,
-                service_group_templates=None, **kwargs):
-        params = self._set(name, protocol=protocol, lb_method=lb_method, hm_name=health_monitor,
-                           service_group_templates=service_group_templates, **kwargs)
+                service_group_templates=None, mem_list=None, hm_name=None, **kwargs):
+        params = self._set(name, protocol=protocol, lb_method=lb_method, hm_name=hm_name,
+                           service_group_templates=service_group_templates,
+                           mem_list=mem_list, **kwargs)
         return self._put(self.url_prefix + name, params, **kwargs)

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -33,13 +33,15 @@ class VirtualServer(base.BaseV30):
         return self._get(self.url_prefix + name)
 
     def _set(self, name, ip_address=None, arp_disable=False, description=None, vrid=None,
-             virtual_server_templates=None, template_virtual_server=None, **kwargs):
+             virtual_server_templates=None, template_virtual_server=None,
+             port_list=None, **kwargs):
         params = {
             "virtual-server": self.minimal_dict({
                 "name": name,
                 "ip-address": ip_address,
                 "arp-disable": None if arp_disable is None else int(arp_disable),
-                "description": description
+                "description": description,
+                "port-list": port_list
             }),
         }
         if self._is_ipv6(ip_address):
@@ -74,21 +76,30 @@ class VirtualServer(base.BaseV30):
         return params
 
     def create(self, name, ip_address, arp_disable=False, description=None, vrid=None,
-               virtual_server_templates=None, template_virtual_server=None, **kwargs):
-        params = self._set(name, ip_address, arp_disable, description, vrid, virtual_server_templates,
-                           template_virtual_server, **kwargs)
+               virtual_server_templates=None, template_virtual_server=None,
+               port_list=None, **kwargs):
+        params = self._set(name, ip_address, arp_disable=arp_disable, description=description,
+                           vrid=vrid, virtual_server_templates=virtual_server_templates,
+                           template_virtual_server=template_virtual_server,
+                           port_list=port_list, **kwargs)
         return self._post(self.url_prefix, params, **kwargs)
 
     def update(self, name, ip_address=None, arp_disable=False, description=None, vrid=None,
-               virtual_server_templates=None, template_virtual_server=None, **kwargs):
-        params = self._set(name, ip_address, arp_disable, description, vrid, virtual_server_templates,
-                           template_virtual_server, **kwargs)
+               virtual_server_templates=None, template_virtual_server=None,
+               port_list=None, **kwargs):
+        params = self._set(name, ip_address, arp_disable=arp_disable, description=description,
+                           vrid=vrid, virtual_server_templates=virtual_server_templates,
+                           template_virtual_server=template_virtual_server,
+                           port_list=port_list, **kwargs)
         return self._post(self.url_prefix + name, params, **kwargs)
 
     def replace(self, name, ip_address=None, arp_disable=False, description=None, vrid=None,
-                virtual_server_templates=None, template_virtual_server=None, **kwargs):
-        params = self._set(name, ip_address, arp_disable, description, vrid, virtual_server_templates,
-                           template_virtual_server, **kwargs)
+                virtual_server_templates=None, template_virtual_server=None,
+                port_list=None, **kwargs):
+        params = self._set(name, ip_address, arp_disable=arp_disable, description=description,
+                           vrid=vrid, virtual_server_templates=virtual_server_templates,
+                           template_virtual_server=template_virtual_server,
+                           port_list=port_list, **kwargs)
         return self._put(self.url_prefix + name, params, **kwargs)
 
     def delete(self, name):


### PR DESCRIPTION
## Description

Severity: Critical

When using the `set` command to update an object, a replace method is called which uses the PUT operation to send a payload. The object on the device is fully overwritten by the contents of this payload, so if the reference objects aren't included then they are removed.

Ex: Virtual server vs1 has a listener l1. When a replace is called without l1 in the port list, then l1 is disassociated from vs1.

## Jira Ticket
[STACK-1699](https://a10networks.atlassian.net/browse/STACK-1699)
[STACK-1703](https://a10networks.atlassian.net/browse/STACK-1703)

## Links
[PR#217 of a10-octavia](https://github.com/a10networks/a10-octavia/pull/217)

## Technical Approach
To fix the issue, a GET call is used to access the contents of the object from which the reference objects are extracted. These objects are then added to the payload as-is so that they aren't removed from the object being updated.

## Config Changes
N/A

## Test Cases
N/A: There isn't any testable logic here everything surrounding this is on the device side.