### PR TITLE
[STACK-1654] healthmonitor support POST method

### DIFF
--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -101,7 +101,8 @@ class HealthMonitor(base.BaseV30):
             if post_data:
                 params['monitor']['method'][mon_method]['post-type'] = "postdata"
                 params['monitor']['method'][mon_method]['http-postdata'] = str(post_data)
-                params['monitor']['method'][mon_method]['post-path'] = params['monitor']['method'][mon_method]['url-path']
+                postpath = params['monitor']['method'][mon_method]['url-path']
+                params['monitor']['method'][mon_method]['post-path'] = postpath
                 params['monitor']['method'][mon_method].pop('url-path', None)
         else:
             params['monitor']['method'][mon_method].pop('post-type', None)
@@ -137,7 +138,7 @@ class HealthMonitor(base.BaseV30):
                method=None, url=None, expect_code=None, port=None, ipv4=None, post_data=None, **kwargs):
         self.get(name)  # We want a NotFound if it does not exist
         return self._set(self.url_prefix, name, mon_type, interval, timeout,
-                         max_retries, method, url, expect_code, port, ipv4, 
+                         max_retries, method, url, expect_code, port, ipv4,
                          update=True, post_data=post_data, **kwargs)
 
     def delete(self, name):

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -68,7 +68,7 @@ class HealthMonitor(base.BaseV30):
         return self._get(self.url_prefix + name, **kwargs)
 
     def _set(self, action, name, mon_method, interval, timeout, max_retries,
-             method=None, url=None, expect_code=None, port=None, ipv4=None, update=False,
+             method=None, url=None, expect_code=None, port=None, ipv4=None, update=False, post_data=None,
              **kwargs):
         params = {
             "monitor": {
@@ -85,7 +85,11 @@ class HealthMonitor(base.BaseV30):
         if method:
             params['monitor']['method'][mon_method]['url-type'] = method
         if url:
-            params['monitor']['method'][mon_method]['url-path'] = url
+            if method == "POST":
+                params['monitor']['method'][mon_method]['post-path'] = url
+                params['monitor']['method'][mon_method].pop('url-path')
+            else:
+                params['monitor']['method'][mon_method]['url-path'] = url
         if expect_code:
             k = "%s-response-code" % mon_method
             params['monitor']['method'][mon_method][k] = str(expect_code)
@@ -96,6 +100,10 @@ class HealthMonitor(base.BaseV30):
                 k = '%s-port' % mon_method
             params['monitor']['method'][mon_method][k] = int(port)
             params['monitor']['override-port'] = int(port)
+        if post_data:
+            if method == "POST":
+                params['monitor']['method'][mon_method]['post-type'] = "postdata"
+                params['monitor']['method'][mon_method]['http-postdata'] = str(post_data)
 
         # TODO(mdurrant) : Might have to get tricky with JSON structures
         # ... due to 'mon_method' stuff.
@@ -110,7 +118,7 @@ class HealthMonitor(base.BaseV30):
         return self._post(action, params, **kwargs)
 
     def create(self, name, mon_type, interval, timeout, max_retries,
-               method=None, url=None, expect_code=None, port=None, ipv4=None, **kwargs):
+               method=None, url=None, expect_code=None, port=None, ipv4=None, post_data=None, **kwargs):
         try:
             self.get(name)
         except acos_errors.NotFound:
@@ -119,15 +127,15 @@ class HealthMonitor(base.BaseV30):
             raise acos_errors.Exists()
 
         return self._set(self.url_prefix, name, mon_type, interval, timeout,
-                         max_retries, method, url, expect_code, port, ipv4, update=False,
-                         **kwargs)
+                         max_retries, method, url, expect_code, port, ipv4,
+                         update=False, post_data=post_data, **kwargs)
 
     def update(self, name, mon_type, interval, timeout, max_retries,
-               method=None, url=None, expect_code=None, port=None, ipv4=None, **kwargs):
+               method=None, url=None, expect_code=None, port=None, ipv4=None, post_data=None, **kwargs):
         self.get(name)  # We want a NotFound if it does not exist
         return self._set(self.url_prefix, name, mon_type, interval, timeout,
-                         max_retries, method, url, expect_code, port, ipv4, update=True,
-                         **kwargs)
+                         max_retries, method, url, expect_code, port, ipv4, 
+                         update=True, post_data=post_data, **kwargs)
 
     def delete(self, name):
         return self._delete(self.url_prefix + name)

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -85,11 +85,7 @@ class HealthMonitor(base.BaseV30):
         if method:
             params['monitor']['method'][mon_method]['url-type'] = method
         if url:
-            if method == "POST":
-                params['monitor']['method'][mon_method]['post-path'] = url
-                params['monitor']['method'][mon_method].pop('url-path')
-            else:
-                params['monitor']['method'][mon_method]['url-path'] = url
+            params['monitor']['method'][mon_method]['url-path'] = url
         if expect_code:
             k = "%s-response-code" % mon_method
             params['monitor']['method'][mon_method][k] = str(expect_code)
@@ -100,10 +96,17 @@ class HealthMonitor(base.BaseV30):
                 k = '%s-port' % mon_method
             params['monitor']['method'][mon_method][k] = int(port)
             params['monitor']['override-port'] = int(port)
-        if post_data:
-            if method == "POST":
+        # handle POST case
+        if params['monitor']['method'][mon_method]['url-type'] == "POST":
+            if post_data:
                 params['monitor']['method'][mon_method]['post-type'] = "postdata"
                 params['monitor']['method'][mon_method]['http-postdata'] = str(post_data)
+                params['monitor']['method'][mon_method]['post-path'] = params['monitor']['method'][mon_method]['url-path']
+                params['monitor']['method'][mon_method].pop('url-path', None)
+        else:
+            params['monitor']['method'][mon_method].pop('post-type', None)
+            params['monitor']['method'][mon_method].pop('http-postdata', None)
+            params['monitor']['method'][mon_method].pop('post-path', None)
 
         # TODO(mdurrant) : Might have to get tricky with JSON structures
         # ... due to 'mon_method' stuff.


### PR DESCRIPTION
command: openstack loadbalancer healthmonitor create --delay 3 --timeout 3 --max-retries 2 **--http-method POST** --type HTTP  sg1 --name hm1

result:
```
health monitor 04c35ba9-5d7e-4318-9a2f-72801f52afd1
  retry 2
  override-port 80
  interval 3 timeout 3
  method http port 80 expect response-code 200 url POST / postdata abc=1
!
slb server 3d21c_192_168_90_132 192.168.90.132
  port 80 tcp
!
slb service-group 1614ea53-9713-4d2d-acab-b151b54eafc1 tcp
  health-check 04c35ba9-5d7e-4318-9a2f-72801f52afd1
  member 3d21c_192_168_90_132 80
!
slb virtual-server 969066ff-afb9-4967-ab4d-adc9d299c8ec 192.168.91.56
  port 80 http
    name f54133b3-032f-4d0d-a69e-bfbe82277f07
    extended-stats
    source-nat auto
    service-group 1614ea53-9713-4d2d-acab-b151b54eafc1
!
```