### PR TITLE
[STACK-1755][STACK-1737] Added port-list reference object attribute to methods for servers

### DIFF
--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -26,16 +26,19 @@ class Server(base.BaseV30):
     def get(self, name, **kwargs):
         return self._get(self.url_prefix + name, **kwargs)
 
-    def _set(self, name, ip_address, status=1, server_templates=None, **kwargs):
+    def _set(self, name, ip_address, status=1, server_templates=None, port_list=None, **kwargs):
         params = {
             "server": {
                 "name": name,
                 "action": 'enable' if status else 'disable',
                 "conn-resume": kwargs.get("conn_resume"),
                 "conn-limit": kwargs.get("conn_limit"),
-                "health-check": kwargs.get("health_check")
+                "health-check": kwargs.get("health_check"),
             }
         }
+
+        if port_list:
+            params['server']['port-list'] = port_list
 
         if self._is_ipv6(ip_address):
             params['server']['server-ipv6-addr'] = ip_address
@@ -54,18 +57,21 @@ class Server(base.BaseV30):
 
         return params
 
-    def create(self, name, ip_address, status=1, server_templates=None, **kwargs):
-        params = self._set(name, ip_address, status=status,
+    def create(self, name, ip_address, status=1, server_templates=None,
+               port_list=None, **kwargs):
+        params = self._set(name, ip_address, status=status, port_list=port_list,
                            server_templates=server_templates, **kwargs)
         return self._post(self.url_prefix, params, **kwargs)
 
-    def update(self, name, ip_address, status=1, server_templates=None, **kwargs):
-        params = self._set(name, ip_address, status=status,
+    def update(self, name, ip_address, status=1, server_templates=None,
+               port_list=None, **kwargs):
+        params = self._set(name, ip_address, status=status, port_list=port_list,
                            server_templates=server_templates, **kwargs)
         return self._post(self.url_prefix + name, params, **kwargs)
 
-    def replace(self, name, ip_address, status=1, server_templates=None, **kwargs):
-        params = self._set(name, ip_address, status=status,
+    def replace(self, name, ip_address, status=1, server_templates=None,
+                port_list=None, **kwargs):
+        params = self._set(name, ip_address, status=status, port_list=port_list,
                            server_templates=server_templates, **kwargs)
         return self._put(self.url_prefix + name, params, **kwargs)
 


### PR DESCRIPTION
## Description

Severity Level: Critical

Whenever members are updated, the real server ports are removed from associated server objects. This has the extra effect of removing the member object from the service group.

## Jira Ticket
[STACK-1755](https://a10networks.atlassian.net/browse/STACK-1755)
[STACK-1737](https://a10networks.atlassian.net/browse/STACK-1737)

## Technical Approach
- Added get call for port-list so that real server ports are obtained

## Linked

[a10-octaiva PR#233](https://github.com/a10networks/a10-octavia/pull/233)

Please see linked PR in a10-octavia for full information regarding requirements of this PR.

## Config Changes
N/A

## Test Cases
N/A - No testable logic. Just a single get call more or less.

## Manual Testing
N/A
