### PR TITLE
Feature/flavor support and acos-client refactor (STACK-1712)

### DIFF
--- a/acos_client/tests/unit/v30/test_bladeparam.py
+++ b/acos_client/tests/unit/v30/test_bladeparam.py
@@ -82,19 +82,22 @@ class TestBlade(unittest.TestCase):
 
     def test_blade_get(self):
         self.target.get(0)
-        self.client.http.request.assert_called_with("GET", self.url_prefix.format(0), {}, mock.ANY)
+        self.client.http.request.assert_called_with("GET", self.url_prefix.format(0), {}, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_create(self):
         self.target.create(4)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
-            self._expected_payload(), mock.ANY)
+            self._expected_payload(), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_create_priority(self):
         self.target.create(4, 122)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
-            self._expected_payload(122), mock.ANY)
+            self._expected_payload(122), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_create_interface(self):
         interface = self._build_interface()
@@ -103,7 +106,8 @@ class TestBlade(unittest.TestCase):
         self.target.create(4)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
-            self._expected_payload(interface=interface), mock.ANY)
+            self._expected_payload(interface=interface), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_create_gateway(self):
         gateway = self._build_ipv4gateway('1.1.1.1')
@@ -112,7 +116,8 @@ class TestBlade(unittest.TestCase):
         self.target.create(4)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
-            self._expected_payload(gateway=gateway), mock.ANY)
+            self._expected_payload(gateway=gateway), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_create_gateway_ipv6(self):
         gateway = self._build_ipv6gateway('1.1.1.1')
@@ -121,7 +126,8 @@ class TestBlade(unittest.TestCase):
         self.target.create(4)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
-            self._expected_payload(gateway=gateway), mock.ANY)
+            self._expected_payload(gateway=gateway), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_create_interface_gateway(self):
         interface = self._build_interface()
@@ -132,19 +138,22 @@ class TestBlade(unittest.TestCase):
         self.target.create(4)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
-            self._expected_payload(interface=interface, gateway=gateway), mock.ANY)
+            self._expected_payload(interface=interface, gateway=gateway), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_update(self):
         self.target.update(4)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
-            self._expected_payload(), mock.ANY)
+            self._expected_payload(), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_update_priority(self):
         self.target.update(4, 122)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
-            self._expected_payload(122), mock.ANY)
+            self._expected_payload(122), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_update_interface(self):
         interface = self._build_interface()
@@ -153,7 +162,8 @@ class TestBlade(unittest.TestCase):
         self.target.update(4)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
-            self._expected_payload(interface=interface), mock.ANY)
+            self._expected_payload(interface=interface), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_update_gateway(self):
         gateway = self._build_ipv4gateway('1.1.1.1')
@@ -162,7 +172,8 @@ class TestBlade(unittest.TestCase):
         self.target.update(4)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
-            self._expected_payload(gateway=gateway), mock.ANY)
+            self._expected_payload(gateway=gateway), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_update_gateway_ipv6(self):
         gateway = self._build_ipv6gateway('1.1.1.1')
@@ -171,7 +182,8 @@ class TestBlade(unittest.TestCase):
         self.target.update(4)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
-            self._expected_payload(gateway=gateway), mock.ANY)
+            self._expected_payload(gateway=gateway), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_blade_update_interface_gateway(self):
         interface = self._build_interface()
@@ -182,4 +194,5 @@ class TestBlade(unittest.TestCase):
         self.target.update(4)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
-            self._expected_payload(interface=interface, gateway=gateway), mock.ANY)
+            self._expected_payload(interface=interface, gateway=gateway), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)

--- a/acos_client/tests/unit/v30/test_dns.py
+++ b/acos_client/tests/unit/v30/test_dns.py
@@ -37,7 +37,8 @@ class TestDns(unittest.TestCase):
         expected_payload = {'primary': {'ip-v4-addr': expected}}
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + 'primary',
-                                                    expected_payload, mock.ANY)
+                                                    expected_payload, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=None)
 
     def test_primary_ipv6(self):
         expected = '0:0:0:0:0:FFFF:129.144.52.38'
@@ -46,7 +47,8 @@ class TestDns(unittest.TestCase):
         expected_payload = {'primary': {'ip-v6-addr': expected}}
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + 'primary',
-                                                    expected_payload, mock.ANY)
+                                                    expected_payload, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=None)
 
     def test_secondary_ipv4(self):
         expected = '192.0.2.5'
@@ -55,7 +57,8 @@ class TestDns(unittest.TestCase):
         expected_payload = {'secondary': {'ip-v4-addr': expected}}
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + 'secondary',
-                                                    expected_payload, mock.ANY)
+                                                    expected_payload, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=None)
 
     def test_secondary_ipv6(self):
         expected = '0:0:0:0:0:FFFF:129.144.52.39'
@@ -64,7 +67,8 @@ class TestDns(unittest.TestCase):
         expected_payload = {'secondary': {'ip-v6-addr': expected}}
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + 'secondary',
-                                                    expected_payload, mock.ANY)
+                                                    expected_payload, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=None)
 
     def test_suffix(self):
         expected = 'example.com'
@@ -73,4 +77,5 @@ class TestDns(unittest.TestCase):
         expected_payload = {'suffix': {'domain-name': expected}}
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + 'suffix',
-                                                    expected_payload, mock.ANY)
+                                                    expected_payload, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=None)

--- a/acos_client/tests/unit/v30/test_interface.py
+++ b/acos_client/tests/unit/v30/test_interface.py
@@ -32,11 +32,13 @@ class TestInterface(unittest.TestCase):
 
     def test_interface_get_list(self):
         self.target.get_list()
-        self.client.http.request.assert_called_with("GET", self.url_prefix, {}, mock.ANY)
+        self.client.http.request.assert_called_with("GET", self.url_prefix, {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=None)
 
     def test_interface_get(self):
         self.target.get()
-        self.client.http.request.assert_called_with("GET", self.url_prefix, {}, mock.ANY)
+        self.client.http.request.assert_called_with("GET", self.url_prefix, {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=None)
 
     def _test_interface_create_dhcp(self, dhcp=True):
         expected = 1 if dhcp else 0
@@ -44,7 +46,8 @@ class TestInterface(unittest.TestCase):
         expected_payload = {self.target.iftype: {'ip': {'dhcp': expected}, 'ifnum': ifnum}}
         self.target.create(ifnum, dhcp=dhcp)
         self.client.http.request.assert_called_with("POST", self.url_prefix,  # URL + ifnum expected
-                                                    expected_payload, mock.ANY)
+                                                    expected_payload, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=None)
 
     def test_interface_create_dhcp_negative(self):
         self._test_interface_create_dhcp(False)
@@ -57,14 +60,15 @@ class TestInterface(unittest.TestCase):
         ip_address = "128.0.0.1"
         ip_netmask = "255.255.255.0"
         self.target.create(ifnum, dhcp=False, ip_address=ip_address, ip_netmask=ip_netmask)
-        self.client.http.request.assert_called_with("POST", self.url_prefix,
-                                                    mock.ANY, mock.ANY)
+        self.client.http.request.assert_called_with("POST", self.url_prefix, mock.ANY, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_interface_delete(self):
         ifnum = 1
         self.target.delete(1)
         self.client.http.request.assert_called_with("DELETE", self.url_prefix + str(ifnum),
-                                                    mock.ANY, mock.ANY)
+                                                    mock.ANY, mock.ANY, axapi_args=None, max_retries=None,
+                                                    timeout=None)
 
     def test_interface_update(self):
         ifnum = 1
@@ -74,7 +78,8 @@ class TestInterface(unittest.TestCase):
         self.target.update(ifnum, dhcp=False, ip_address=ip_address, ip_netmask=ip_netmask)
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + str(ifnum),
-                                                    mock.ANY, mock.ANY)
+                                                    mock.ANY, mock.ANY, axapi_args=None, max_retries=None,
+                                                    timeout=None)
 
     def test_interface_enable_positive(self):
         ifnum = 1
@@ -88,7 +93,8 @@ class TestInterface(unittest.TestCase):
         self.assertEqual("enable", params[self.target.iftype]["action"])
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + str(ifnum),
-                                                    mock.ANY, mock.ANY)
+                                                    mock.ANY, mock.ANY, axapi_args=None, max_retries=None,
+                                                    timeout=None)
 
     def test_interface_enable_negative(self):
         ifnum = 1
@@ -103,7 +109,8 @@ class TestInterface(unittest.TestCase):
         self.assertEqual("disable", params[self.target.iftype]["action"])
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + str(ifnum),
-                                                    mock.ANY, mock.ANY)
+                                                    mock.ANY, mock.ANY, axapi_args=None, max_retries=None,
+                                                    timeout=None)
 
 
 class TestEthernetInterface(TestInterface):

--- a/acos_client/tests/unit/v30/test_port.py
+++ b/acos_client/tests/unit/v30/test_port.py
@@ -33,8 +33,6 @@ class TestPort(unittest.TestCase):
     def test_create_port(self):
         expected = {
             'port': {
-                "conn-resume": None,
-                "conn-limit": None,
                 "stats-data-action": "stats-data-enable",
                 "weight": 1,
                 "port-number": 80,
@@ -51,20 +49,45 @@ class TestPort(unittest.TestCase):
         self.assertEqual(url, '/axapi/v3/slb/server/%s/port/' % self._server_name)
         self.assertEqual(params, expected)
 
-    def test_update_port(self):
+    def test_create_port_with_params(self):
         expected = {
             'port': {
-                "conn-resume": None,
-                "conn-limit": 12345,
-                "stats-data-action": "stats-data-enable",
-                "weight": 2,
+                "conn-resume": 500,
+                "conn-limit": 600,
+                "stats-data-action": "stats-data-disable",
+                "weight": 3,
                 "port-number": 80,
-                "range": 0,
-                "action": "enable",
+                "range": 30,
+                "action": "disable-with-health-check",
                 "protocol": 'tcp'
             }
         }
-        self.port.update('test_server', 80, 'tcp', conn_limit=12345, weight=2)
+        self.port.create('test_server', 80, 'tcp', conn_resume=500, conn_limit=600,
+                         stats_data_action="stats-data-disable", weight=3, range=30,
+                         action="disable-with-health-check")
+
+        ((method, url, params, header), kwargs) = self.client.http.request.call_args
+
+        self.assertEqual(method, 'POST')
+        self.assertEqual(url, '/axapi/v3/slb/server/%s/port/' % self._server_name)
+        self.assertEqual(params, expected)
+
+    def test_update_port(self):
+        expected = {
+            'port': {
+                "conn-resume": 500,
+                "conn-limit": 600,
+                "stats-data-action": "stats-data-disable",
+                "weight": 3,
+                "port-number": 80,
+                "range": 30,
+                "action": "disable-with-health-check",
+                "protocol": 'tcp'
+            }
+        }
+        self.port.update('test_server', 80, 'tcp', conn_resume=500, conn_limit=600,
+                         stats_data_action="stats-data-disable", weight=3, range=30,
+                         action="disable-with-health-check")
 
         ((method, url, params, header), kwargs) = self.client.http.request.call_args
 

--- a/acos_client/tests/unit/v30/test_slb_server.py
+++ b/acos_client/tests/unit/v30/test_slb_server.py
@@ -91,6 +91,35 @@ class TestServer(unittest.TestCase):
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
     @responses.activate
+    def test_server_create_with_kwargs(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {'foo': 'bar'}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        params = {
+            'server': {
+                'action': 'enable',
+                'conn-limit': 400,
+                'conn-resume': 500,
+                'health-check': None,
+                'host': '192.168.2.254',
+                'name': VSERVER_NAME,
+            }
+        }
+        kwargs = {
+            'conn_resume': 500,
+            'server': {
+                'conn_limit': 400,
+            }
+        }
+        resp = self.client.slb.server.create('test', '192.168.2.254', **kwargs)
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @responses.activate
     def test_server_update_with_template(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {'foo': 'bar'}
@@ -110,6 +139,35 @@ class TestServer(unittest.TestCase):
             "template-server": "test-template-server"
         }
         resp = self.client.slb.server.update('test', '192.168.2.254', server_templates=templates)
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @responses.activate
+    def test_server_update_with_kwargs(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {'foo': 'bar'}
+        responses.add(responses.POST, OBJECT_URL, json=json_response, status=200)
+        params = {
+            'server': {
+                'action': 'enable',
+                'conn-limit': 400,
+                'conn-resume': 500,
+                'host': '192.168.2.254',
+                'name': VSERVER_NAME,
+                'health-check': None,
+            }
+        }
+        kwargs = {
+            'conn_resume': 500,
+            'server': {
+                'conn_limit': 400,
+            }
+        }
+        resp = self.client.slb.server.update('test', '192.168.2.254', **kwargs)
 
         self.assertEqual(resp, json_response)
         self.assertEqual(len(responses.calls), 2)

--- a/acos_client/tests/unit/v30/test_slb_service_group.py
+++ b/acos_client/tests/unit/v30/test_slb_service_group.py
@@ -84,6 +84,43 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
     @responses.activate
+    def test_server_group_create_with_kwargs(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, CREATE_URL, json=json_response, status=200)
+        templates = {
+            'template-server': 'template_sv',
+            'template-port': 'template_port',
+            'template-policy': 'template-pl'
+        }
+        args = {
+            'service_group':
+            {
+                'health_check_disable': 1,
+            }
+        }
+        resp = self.client.slb.service_group.create('test1', service_group_templates=templates, **args)
+        params = {
+            'service-group':
+            {
+                'health-check-disable': 1,
+                'lb-method': 'round-robin',
+                'name': 'test1',
+                'protocol': 'tcp',
+                'stateless-auto-switch': 0,
+                'template-server': 'template_sv',
+                'template-port': 'template_port',
+                'template-policy': 'template-pl'
+            }
+        }
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @responses.activate
     def test_server_group_create_with_partial_templates(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         json_response = {"foo": "bar"}
@@ -126,6 +163,32 @@ class TestVirtualServer(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+
+    @responses.activate
+    def test_server_group_update_with_kwargs(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, OBJECT_URL, json=json_response, status=200)
+        args = {
+            'service_group':
+            {
+                'health_check_disable': 1,
+            }
+        }
+        resp = self.client.slb.service_group.update('test1', **args)
+        params = {
+            'service-group':
+            {
+                'health-check-disable': 1,
+                'name': 'test1',
+            }
+        }
+
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
     @responses.activate
     def test_server_group_replace(self):

--- a/acos_client/tests/unit/v30/test_slb_virtual_port.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_port.py
@@ -59,7 +59,7 @@ class TestVirtualPort(unittest.TestCase):
         }
 
         resp = self.client.slb.virtual_server.vport.create(
-            VSERVER_NAME, 'test1_VPORT', protocol=self.client.slb.virtual_server.vport.HTTP, port='80',
+            VSERVER_NAME, 'test1_VPORT', protocol=self.client.slb.virtual_server.vport.HTTP, protocol_port='80',
             service_group_name='pool1'
         )
 
@@ -99,7 +99,7 @@ class TestVirtualPort(unittest.TestCase):
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',
             protocol=self.client.slb.virtual_server.vport.HTTP,
-            port='80',
+            protocol_port='80',
             service_group_name='pool1',
             s_pers_name="test_s_pers_template",
             c_pers_name="test_c_pers_template",
@@ -143,20 +143,17 @@ class TestVirtualPort(unittest.TestCase):
             }
         }
         kwargs = {
-            'virtual_port': {
-                'conn_limit': 400,
-            }
+            'conn_limit': 400,
         }
 
         resp = self.client.slb.virtual_server.vport.create(
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',
             protocol=self.client.slb.virtual_server.vport.HTTP,
-            port='80',
+            protocol_port='80',
             service_group_name='pool1',
             ha_conn_mirror=1,
             no_dest_nat=1,
-            conn_limit=50000,
             status=1,
             autosnat=True,
             ipinip=True,
@@ -181,7 +178,7 @@ class TestVirtualPort(unittest.TestCase):
 
         with self.assertRaises(acos_errors.ACOSException):
             self.client.slb.virtual_server.vport.create(
-                VSERVER_NAME, 'test1_VPORT', protocol=self.client.slb.virtual_server.vport.HTTP, port='80',
+                VSERVER_NAME, 'test1_VPORT', protocol=self.client.slb.virtual_server.vport.HTTP, protocol_port='80',
                 service_group_name='pool1'
             )
 
@@ -210,7 +207,7 @@ class TestVirtualPort(unittest.TestCase):
         }
 
         resp = self.client.slb.virtual_server.vport.update(
-            VSERVER_NAME, 'test1_VPORT', protocol=self.client.slb.virtual_server.vport.HTTP, port='80',
+            VSERVER_NAME, 'test1_VPORT', protocol=self.client.slb.virtual_server.vport.HTTP, protocol_port='80',
             service_group_name='pool1'
         )
 
@@ -272,7 +269,7 @@ class TestVirtualPort(unittest.TestCase):
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',
             protocol=self.client.slb.virtual_server.vport.HTTP,
-            port='80',
+            protocol_port='80',
             service_group_name='pool1',
             s_pers_name="test_s_pers_template",
             c_pers_name="test_c_pers_template",
@@ -346,7 +343,7 @@ class TestVirtualPort(unittest.TestCase):
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',
             protocol=self.client.slb.virtual_server.vport.HTTP,
-            port='80',
+            protocol_port='80',
             service_group_name='pool1',
             s_pers_name="test_s_pers_template",
             c_pers_name="test_c_pers_template",
@@ -400,7 +397,7 @@ class TestVirtualPort(unittest.TestCase):
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',
             protocol=self.client.slb.virtual_server.vport.HTTP,
-            port='80',
+            protocol_port='80',
             service_group_name='pool1',
             s_pers_name="test_s_pers_template",
             c_pers_name="test_c_pers_template",
@@ -448,16 +445,14 @@ class TestVirtualPort(unittest.TestCase):
             }
         }
         kwargs = {
-            'virtual_port': {
-                'conn-limit': 400
-            }
+            'conn_limit': 400
         }
 
         resp = self.client.slb.virtual_server.vport.update(
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',
             protocol=self.client.slb.virtual_server.vport.HTTP,
-            port='80',
+            protocol_port='80',
             service_group_name='pool1',
             s_pers_name="test_s_pers_template",
             c_pers_name="test_c_pers_template",
@@ -466,7 +461,6 @@ class TestVirtualPort(unittest.TestCase):
             ipinip=True,
             ha_conn_mirror=1,
             no_dest_nat=1,
-            conn_limit=50000,
             source_nat_pool="test_nat_pool",
             use_rcv_hop=True,
             **kwargs
@@ -535,7 +529,7 @@ class TestVirtualPort(unittest.TestCase):
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',
             protocol=self.client.slb.virtual_server.vport.HTTP,
-            port='80',
+            protocol_port='80',
             service_group_name='pool1',
             s_pers_name="test_s_pers_template",
             c_pers_name="test_c_pers_template",
@@ -592,7 +586,7 @@ class TestVirtualPort(unittest.TestCase):
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',
             protocol=self.client.slb.virtual_server.vport.HTTP,
-            port='80',
+            protocol_port='80',
             service_group_name='pool1',
             s_pers_name="test_s_pers_template",
             c_pers_name="test_c_pers_template",
@@ -671,7 +665,7 @@ class TestVirtualPort(unittest.TestCase):
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',
             protocol=self.client.slb.virtual_server.vport.HTTP,
-            port='80',
+            protocol_port='80',
             service_group_name='pool1',
             s_pers_name="test_s_pers_template",
             c_pers_name="test_c_pers_template",

--- a/acos_client/tests/unit/v30/test_vlan.py
+++ b/acos_client/tests/unit/v30/test_vlan.py
@@ -34,12 +34,14 @@ class TestVlan(unittest.TestCase):
 
     def test_interface_get_list(self):
         self.target.get_list()
-        self.client.http.request.assert_called_with("GET", self.url_prefix, {}, mock.ANY)
+        self.client.http.request.assert_called_with("GET", self.url_prefix, {}, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_interface_get(self):
         self.target.get(self.vlan_id)
         self.client.http.request.assert_called_with(
-            "GET", '{0}/{1}'.format(self.url_prefix, self.vlan_id), {}, mock.ANY
+            "GET", '{0}/{1}'.format(self.url_prefix, self.vlan_id), {}, mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None
         )
 
     def test_vlan_create_shared(self):
@@ -48,8 +50,8 @@ class TestVlan(unittest.TestCase):
 
         ep = self.expected_payload
         ep['vlan']['shared-vlan'] = True
-        self.client.http.request.assert_called_with("POST", self.url_prefix,
-                                                    ep, mock.ANY)
+        self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_vlan_create_untagged_eths(self):
         untagged_eths = [{'untagged-ethernet-start': 2, 'untagged-ethernet-end': 2}]
@@ -59,8 +61,8 @@ class TestVlan(unittest.TestCase):
 
         ep = self.expected_payload
         ep['vlan']['untagged-eth-list'] = untagged_eths
-        self.client.http.request.assert_called_with("POST", self.url_prefix,
-                                                    ep, mock.ANY)
+        self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_vlan_create_untagged_trunks(self):
         untagged_trunks = [{'untagged-trunk-start': 2, 'untagged-trunk-end': 2}]
@@ -71,8 +73,8 @@ class TestVlan(unittest.TestCase):
 
         ep = self.expected_payload
         ep['vlan']['untagged-trunk-list'] = untagged_trunks
-        self.client.http.request.assert_called_with("POST", self.url_prefix,
-                                                    ep, mock.ANY)
+        self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_vlan_create_tagged_eths(self):
         tagged_eths = [{'tagged-ethernet-start': 2, 'tagged-ethernet-end': 2}]
@@ -82,8 +84,8 @@ class TestVlan(unittest.TestCase):
 
         ep = self.expected_payload
         ep['vlan']['tagged-eth-list'] = tagged_eths
-        self.client.http.request.assert_called_with("POST", self.url_prefix,
-                                                    ep, mock.ANY)
+        self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_vlan_create_tagged_trunks(self):
         tagged_trunks = [{'tagged-trunk-start': 2, 'tagged-trunk-end': 2}]
@@ -93,8 +95,8 @@ class TestVlan(unittest.TestCase):
 
         ep = self.expected_payload
         ep['vlan']['tagged-trunk-list'] = tagged_trunks
-        self.client.http.request.assert_called_with("POST", self.url_prefix,
-                                                    ep, mock.ANY)
+        self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_vlan_create_ve(self):
         self.target.create(self.vlan_id, shared_vlan=False, untagged_eths=[], untagged_trunks=[],
@@ -102,8 +104,8 @@ class TestVlan(unittest.TestCase):
 
         ep = self.expected_payload
         ep['vlan']['ve'] = 1
-        self.client.http.request.assert_called_with("POST", self.url_prefix,
-                                                    ep, mock.ANY)
+        self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_vlan_create_lif(self):
         self.target.create(self.vlan_id, shared_vlan=False, untagged_eths=[], untagged_trunks=[],
@@ -111,11 +113,12 @@ class TestVlan(unittest.TestCase):
 
         ep = self.expected_payload
         ep['vlan']['untagged-lif'] = 6
-        self.client.http.request.assert_called_with("POST", self.url_prefix,
-                                                    ep, mock.ANY)
+        self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_vlan_delete(self):
         self.target.delete(self.vlan_id)
         self.client.http.request.assert_called_with(
-            "DELETE", '{0}/{1}'.format(self.url_prefix, self.vlan_id), mock.ANY, mock.ANY
+            "DELETE", '{0}/{1}'.format(self.url_prefix, self.vlan_id), mock.ANY, mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None
         )

--- a/acos_client/tests/unit/v30/test_vrrpa.py
+++ b/acos_client/tests/unit/v30/test_vrrpa.py
@@ -45,35 +45,40 @@ class TestVRID(unittest.TestCase):
 
     def test_vrid_get(self):
         self.target.get(0)
-        self.client.http.request.assert_called_with("GET", self.url_prefix + '0', {}, mock.ANY)
+        self.client.http.request.assert_called_with("GET", self.url_prefix + '0', {}, mock.ANY,
+                                                    axapi_args=None, max_retries=None, timeout=None)
 
     def test_vrid_create_threshold(self):
         self.target.create(4, threshold=2)
         self.client.http.request.assert_called_with(
-            "POST", self.url_prefix, self.expected_payload(4, threshold=2), mock.ANY)
+            "POST", self.url_prefix, self.expected_payload(4, threshold=2), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_vrid_create_disable(self):
         self.target.create(4, disable=1)
         self.client.http.request.assert_called_with(
-            "POST", self.url_prefix, self.expected_payload(4, disable=1), mock.ANY)
+            "POST", self.url_prefix, self.expected_payload(4, disable=1), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_vrid_create_floating_ip(self):
         self.target.create(4, threshold=1, disable=0, floating_ips=['10.10.10.8'])
         payload = self.expected_payload(4)
         payload['vrid']['floating-ip'] = mock.ANY
         self.client.http.request.assert_called_with(
-            "POST", self.url_prefix, payload,
-            mock.ANY)
+            "POST", self.url_prefix, payload, mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_vrid_update_threshold(self):
         self.target.update(4, threshold=2)
         self.client.http.request.assert_called_with(
-            "PUT", self.url_prefix + '4', self.expected_payload(4, threshold=2), mock.ANY)
+            "PUT", self.url_prefix + '4', self.expected_payload(4, threshold=2), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_vrid_update_disable(self):
         self.target.update(4, disable=1)
         self.client.http.request.assert_called_with(
-            "PUT", self.url_prefix + '4', self.expected_payload(4, disable=1), mock.ANY)
+            "PUT", self.url_prefix + '4', self.expected_payload(4, disable=1), mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_vrid_update_floating_ip(self):
         self.target.update(4, threshold=1, disable=0, floating_ips=['10.10.10.9'])
@@ -81,21 +86,23 @@ class TestVRID(unittest.TestCase):
         payload['vrid']['floating-ip'] = mock.ANY
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix + '4', payload,
-            mock.ANY)
+            mock.ANY, axapi_args=None, max_retries=None, timeout=None)
 
     def test_patition_vrid_create_floating_ip(self):
         self.target.create(4, threshold=1, disable=0, floating_ips=['10.10.10.8'], is_partition=True)
         payload = self.expected_payload(4, is_partition=True)
         payload['vrid']['floating-ip'] = mock.ANY
         self.client.http.request.assert_called_with(
-            "POST", self.url_prefix, payload, mock.ANY)
+            "POST", self.url_prefix, payload, mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_partition_vrid_update_floating_ip(self):
         self.target.update(4, threshold=1, disable=0, floating_ips=['10.10.10.9'], is_partition=True)
         payload = self.expected_payload(4, is_partition=True)
         payload['vrid']['floating-ip'] = mock.ANY
         self.client.http.request.assert_called_with(
-            "PUT", self.url_prefix + '4', payload, mock.ANY)
+            "PUT", self.url_prefix + '4', payload, mock.ANY,
+            axapi_args=None, max_retries=None, timeout=None)
 
     def test_build_params_multi_ip(self):
         floating_ips = ['11.11.11.11', '12.12.12.12', '13.13.13.13']

--- a/acos_client/v30/base.py
+++ b/acos_client/v30/base.py
@@ -50,13 +50,15 @@ class BaseV30(object):
         self.auth_header['Authorization'] = "A10 %s" % self.client.session.id
         return ("/axapi/v3" + action)
 
-    def _request(self, method, action, params, retry_count=0, **kwargs):
+    def _request(self, method, action, params, retry_count=0, max_retries=None,
+                 timeout=None, axapi_args=None, **kwargs):
         if retry_count > 24:
             raise ae.ACOSUnknownError()
 
         try:
-            return self.client.http.request(method, self.url(action), params,
-                                            self.auth_header, **kwargs)
+            return self.client.http.request(method, self.url(action), params, self.auth_header,
+                                            max_retries=max_retries, timeout=timeout,
+                                            axapi_args=axapi_args, **kwargs)
         except (ae.InvalidSessionID, ae.ConfigManagerNotReady) as e:
             if type(e) == ae.ConfigManagerNotReady:
                 retry_limit = 24
@@ -73,20 +75,25 @@ class BaseV30(object):
                     self.client.partition.active(p)
                 except Exception:
                     pass
-                return self._request(method, action, params, retry_count + 1, **kwargs)
+                return self._request(method, action, params, retry_count + 1, max_retries=max_retries,
+                                     timeout=timeout, axapi_args=axapi_args, **kwargs)
             raise e
 
-    def _get(self, action, params={}, **kwargs):
-        return self._request('GET', action, params, **kwargs)
+    def _get(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
+        return self._request('GET', action, params, max_retries=max_retries, timeout=timeout,
+                             axapi_args=axapi_args, **kwargs)
 
-    def _post(self, action, params={}, **kwargs):
-        return self._request('POST', action, params, **kwargs)
+    def _post(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
+        return self._request('POST', action, params, max_retries=max_retries, timeout=timeout,
+                             axapi_args=axapi_args, **kwargs)
 
-    def _put(self, action, params={}, **kwargs):
-        return self._request('PUT', action, params, **kwargs)
+    def _put(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
+        return self._request('PUT', action, params, max_retries=max_retries, timeout=timeout,
+                             axapi_args=axapi_args, **kwargs)
 
-    def _delete(self, action, params={}, **kwargs):
-        return self._request('DELETE', action, params, **kwargs)
+    def _delete(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
+        return self._request('DELETE', action, params, max_retries=max_retries, timeout=timeout,
+                             axapi_args=axapi_args, **kwargs)
 
     def _is_ipv6(self, ip_address):
         validated_ip_address = ipaddress.ip_address(six.text_type(ip_address))

--- a/acos_client/v30/base.py
+++ b/acos_client/v30/base.py
@@ -31,21 +31,6 @@ class BaseV30(object):
     def minimal_dict(self, my_dict, exclude=[]):
         return dict((k, v) for k, v in my_dict.items() if v is not None or k in exclude)
 
-    def dict_underscore_to_dash(self, my_dict, exclude=['config_defaults', 'axapi_args']):
-        if type(my_dict) is list:
-            item_list = []
-            for item in my_dict:
-                item_list.append(self.dict_underscore_to_dash(item), exclude)
-            return item_list
-        elif type(my_dict) is dict:
-            item_dict = {}
-            for k, v in my_dict.items():
-                if k not in exclude:
-                    item_dict[k.replace('_', '-')] = self.dict_underscore_to_dash(v, exclude)
-            return item_dict
-        else:
-            return my_dict
-
     def url(self, action):
         self.auth_header['Authorization'] = "A10 %s" % self.client.session.id
         return ("/axapi/v3" + action)

--- a/acos_client/v30/base.py
+++ b/acos_client/v30/base.py
@@ -31,6 +31,21 @@ class BaseV30(object):
     def minimal_dict(self, my_dict, exclude=[]):
         return dict((k, v) for k, v in my_dict.items() if v is not None or k in exclude)
 
+    def dict_underscore_to_dash(self, my_dict, exclude=['config_defaults', 'axapi_args']):
+        if type(my_dict) is list:
+            item_list = []
+            for item in my_dict:
+                item_list.append(self.dict_underscore_to_dash(item), exclude)
+            return item_list
+        elif type(my_dict) is dict:
+            item_dict = {}
+            for k, v in my_dict.items():
+                if k not in exclude:
+                    item_dict[k.replace('_', '-')] = self.dict_underscore_to_dash(v, exclude)
+            return item_dict
+        else:
+            return my_dict
+
     def url(self, action):
         self.auth_header['Authorization'] = "A10 %s" % self.client.session.id
         return ("/axapi/v3" + action)

--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import six
 
-
+import acos_client
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
 
@@ -112,10 +112,15 @@ class HealthMonitor(base.BaseV30):
         # TODO(mdurrant) : Might have to get tricky with JSON structures
         # ... due to 'mon_method' stuff.
         config_defaults = kwargs.get("config_defaults")
-
         if config_defaults:
             for k, v in six.iteritems(config_defaults):
                 params['monitor'][k] = v
+
+        # put options from flavor (and conf)
+        options = {}
+        options['monitor'] = self.dict_underscore_to_dash(kwargs.pop('monitor', None))
+        if options['monitor']:
+            params = acos_client.v21.axapi_http.merge_dicts(params, options)
 
         if update:
             action += name

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -13,9 +13,7 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import six
 
-import acos_client
 from acos_client.v30 import base
 from acos_client.v30.slb.port import Port
 
@@ -24,17 +22,19 @@ class Server(base.BaseV30):
 
     url_prefix = '/slb/server/'
 
-    def get(self, name, **kwargs):
-        return self._get(self.url_prefix + name, **kwargs)
+    def get(self, name, max_retries=None, timeout=None, **kwargs):
+        return self._get(self.url_prefix + name, max_retries=max_retries, timeout=timeout,
+                         axapi_args=kwargs)
 
-    def _set(self, name, ip_address, status=1, server_templates=None, port_list=None, **kwargs):
+    def _set(self, name, ip_address, status=1, server_templates=None, port_list=None,
+             conn_resume=None, conn_limit=None, health_check=None, **kwargs):
         params = {
             "server": {
                 "name": name,
                 "action": 'enable' if status else 'disable',
-                "conn-resume": kwargs.get("conn_resume"),
-                "conn-limit": kwargs.get("conn_limit"),
-                "health-check": kwargs.get("health_check"),
+                "conn-resume": conn_resume,
+                "conn-limit": conn_limit,
+                "health-check": health_check,
             }
         }
 
@@ -50,36 +50,34 @@ class Server(base.BaseV30):
             server_templates = {k: v for k, v in server_templates.items() if v}
             params['server']['template-server'] = server_templates.get('template-server')
 
-        config_defaults = kwargs.get("config_defaults")
-        if config_defaults:
-            for k, v in six.iteritems(config_defaults):
-                params['server'][k] = v
-
-        # put options from flavor (and conf)
-        options = {}
-        options['server'] = self.dict_underscore_to_dash(kwargs.pop('server', None))
-        if options['server']:
-            params = acos_client.v21.axapi_http.merge_dicts(params, options)
-
         return params
 
     def create(self, name, ip_address, status=1, server_templates=None,
-               port_list=None, **kwargs):
+               port_list=None, max_retries=None, timeout=None,
+               conn_resume=None, conn_limit=None, health_check=None, **kwargs):
         params = self._set(name, ip_address, status=status, port_list=port_list,
+                           conn_resume=conn_resume, conn_limit=conn_limit, health_check=health_check,
                            server_templates=server_templates, **kwargs)
-        return self._post(self.url_prefix, params, **kwargs)
+        return self._post(self.url_prefix, params, max_retries=max_retries, timeout=timeout,
+                          axapi_args=kwargs)
 
     def update(self, name, ip_address, status=1, server_templates=None,
-               port_list=None, **kwargs):
+               port_list=None, max_retries=None, timeout=None,
+               conn_resume=None, conn_limit=None, health_check=None, **kwargs):
         params = self._set(name, ip_address, status=status, port_list=port_list,
+                           conn_resume=conn_resume, conn_limit=conn_limit, health_check=health_check,
                            server_templates=server_templates, **kwargs)
-        return self._post(self.url_prefix + name, params, **kwargs)
+        return self._post(self.url_prefix + name, params, max_retries=max_retries, timeout=timeout,
+                          axapi_args=kwargs)
 
     def replace(self, name, ip_address, status=1, server_templates=None,
-                port_list=None, **kwargs):
+                port_list=None, max_retries=None, timeout=None,
+                conn_resume=None, conn_limit=None, health_check=None, **kwargs):
         params = self._set(name, ip_address, status=status, port_list=port_list,
+                           conn_resume=conn_resume, conn_limit=conn_limit, health_check=health_check,
                            server_templates=server_templates, **kwargs)
-        return self._put(self.url_prefix + name, params, **kwargs)
+        return self._put(self.url_prefix + name, params, max_retries=max_retries, timeout=timeout,
+                         axapi_args=kwargs)
 
     def delete(self, name):
         return self._delete(self.url_prefix + name)

--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import six
 
+import acos_client
 from acos_client.v30 import base
 from acos_client.v30.slb.port import Port
 
@@ -50,10 +51,15 @@ class Server(base.BaseV30):
             params['server']['template-server'] = server_templates.get('template-server')
 
         config_defaults = kwargs.get("config_defaults")
-
         if config_defaults:
             for k, v in six.iteritems(config_defaults):
                 params['server'][k] = v
+
+        # put options from flavor (and conf)
+        options = {}
+        options['server'] = self.dict_underscore_to_dash(kwargs.pop('server', None))
+        if options['server']:
+            params = acos_client.v21.axapi_http.merge_dicts(params, options)
 
         return params
 

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import six
 
+import acos_client
 from acos_client.v30 import base
 from acos_client.v30.slb.member import Member
 
@@ -106,10 +107,15 @@ class ServiceGroup(base.BaseV30):
             params['service-group']['template-port'] = service_group_templates.get('template-port', None)
 
         config_defaults = kwargs.get("config_defaults")
-
         if config_defaults:
             for k, v in six.iteritems(config_defaults):
                 params['service-group'][k] = v
+
+        # put options from flavor (and conf)
+        options = {}
+        options['service-group'] = self.dict_underscore_to_dash(kwargs.pop('service_group', None))
+        if options['service-group']:
+            params = acos_client.v21.axapi_http.merge_dicts(params, options)
 
         return params
 

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -13,9 +13,7 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import six
 
-import acos_client
 from acos_client.v30 import base
 from acos_client.v30.slb.member import Member
 
@@ -53,7 +51,8 @@ class ServiceGroup(base.BaseV30):
     UDP = 'udp'
 
     def _set(self, name, protocol=None, lb_method=None, service_group_templates=None,
-             hm_name=None, mem_list=None, **kwargs):
+             hm_name=None, mem_list=None, health_check_disable=False, health_check=None,
+             **kwargs):
 
         # Normalize "" -> None for json
         hm_name = hm_name or None
@@ -70,7 +69,7 @@ class ServiceGroup(base.BaseV30):
 
         # If we explicitly disable health checks, ensure it happens
         # Else, we implicitly disable health checks if not specified.
-        health_check_disable = 1 if kwargs.get("health_check_disable", False) else 0
+        health_check_disable = 1 if health_check_disable else 0
 
         # When enabling/disabling a health monitor, you can't specify
         # health-check-disable and health-check at the same time.
@@ -78,8 +77,8 @@ class ServiceGroup(base.BaseV30):
             params["service-group"]["health-check-disable"] = health_check_disable
             # Have to explicitly detach health monitor from the service group,
             # by setting health_check parameter to None.
-            if 'health_check' in kwargs:
-                params["service-group"]["health-check"] = kwargs['health_check']
+            if health_check:
+                params["service-group"]["health-check"] = health_check
         else:
             params["service-group"]["health-check"] = hm_name
 
@@ -106,57 +105,58 @@ class ServiceGroup(base.BaseV30):
             params['service-group']['template-server'] = service_group_templates.get('template-server', None)
             params['service-group']['template-port'] = service_group_templates.get('template-port', None)
 
-        config_defaults = kwargs.get("config_defaults")
-        if config_defaults:
-            for k, v in six.iteritems(config_defaults):
-                params['service-group'][k] = v
-
-        # put options from flavor (and conf)
-        options = {}
-        options['service-group'] = self.dict_underscore_to_dash(kwargs.pop('service_group', None))
-        if options['service-group']:
-            params = acos_client.v21.axapi_http.merge_dicts(params, options)
-
         return params
 
-    def all(self, *args, **kwargs):
-        return self._get(self.url_prefix, **kwargs)
+    def all(self, max_retries=None, timeout=None, *args, **kwargs):
+        return self._get(self.url_prefix, max_retries=max_retries, timeout=timeout, axapi_args=kwargs)
 
-    def all_stats(self, *args, **kwargs):
-        return self._get(self.url_prefix + "stats", **kwargs)
+    def all_stats(self, max_retries=None, timeout=None, *args, **kwargs):
+        return self._get(self.url_prefix + "stats", max_retries=max_retries, timeout=timeout, axapi_args=kwargs)
 
-    def all_oper(self, *args, **kwargs):
-        return self._get(self.url_prefix + "oper", **kwargs)
+    def all_oper(self, max_retries=None, timeout=None, *args, **kwargs):
+        return self._get(self.url_prefix + "oper", max_retries=max_retries, timeout=timeout, axapi_args=kwargs)
 
     def create(self, name, protocol=TCP, lb_method=ROUND_ROBIN, service_group_templates=None,
-               mem_list=None, hm_name=None, **kwargs):
+               mem_list=None, hm_name=None, max_retries=None, timeout=None, health_check_disable=False,
+               health_check=None, **kwargs):
         params = self._set(name, protocol=protocol, lb_method=lb_method,
                            service_group_templates=service_group_templates,
-                           mem_list=mem_list, hm_name=hm_name, **kwargs)
-        return self._post(self.url_prefix, params, **kwargs)
+                           mem_list=mem_list, hm_name=hm_name, health_check_disable=health_check_disable,
+                           health_check=health_check, **kwargs)
+        return self._post(self.url_prefix, params, max_retries=max_retries, timeout=timeout, axapi_args=kwargs)
 
     def delete(self, name):
         return self._delete(self.url_prefix + name)
 
-    def get(self, name, **kwargs):
-        return self._get(self.url_prefix + name, **kwargs)
+    def get(self, name, max_retries=None, timeout=None, **kwargs):
+        return self._get(self.url_prefix + name, max_retries=max_retries, timeout=timeout, axapi_args=kwargs)
 
-    def oper(self, name, *args, **kwargs):
-        return self._get(self.url_prefix + name + "/oper", **kwargs)
+    def oper(self, name, max_retries=None, timeout=None, *args, **kwargs):
+        return self._get(self.url_prefix + name + "/oper", max_retries=max_retries, timeout=timeout,
+                         axapi_args=kwargs)
 
-    def stats(self, name, *args, **kwargs):
-        return self._get(self.url_prefix + name + "/stats", **kwargs)
+    def stats(self, name, max_retries=None, timeout=None, *args, **kwargs):
+        return self._get(self.url_prefix + name + "/stats", max_retries=max_retries, timeout=timeout,
+                         axapi_args=kwargs)
 
     def update(self, name, protocol=None, lb_method=None, health_monitor=None,
-               service_group_templates=None, mem_list=None, hm_name=None, **kwargs):
+               service_group_templates=None, mem_list=None, hm_name=None,
+               max_retries=None, timeout=None, health_check_disable=False, health_check=None,
+               **kwargs):
         params = self._set(name, protocol=None, lb_method=lb_method, hm_name=hm_name,
                            service_group_templates=service_group_templates,
-                           mem_list=mem_list, **kwargs)
-        return self._post(self.url_prefix + name, params, **kwargs)
+                           mem_list=mem_list, health_check_disable=health_check_disable,
+                           health_check=health_check, **kwargs)
+        return self._post(self.url_prefix + name, params, max_retries=max_retries, timeout=timeout,
+                          axapi_args=kwargs)
 
     def replace(self, name, protocol=None, lb_method=None, health_monitor=None,
-                service_group_templates=None, mem_list=None, hm_name=None, **kwargs):
+                service_group_templates=None, mem_list=None, hm_name=None,
+                max_retries=None, timeout=None, health_check_disable=False, health_check=None,
+                **kwargs):
         params = self._set(name, protocol=protocol, lb_method=lb_method, hm_name=hm_name,
                            service_group_templates=service_group_templates,
-                           mem_list=mem_list, **kwargs)
-        return self._put(self.url_prefix + name, params, **kwargs)
+                           mem_list=mem_list, health_check_disable=health_check_disable,
+                           health_check=health_check, **kwargs)
+        return self._put(self.url_prefix + name, params, max_retries=max_retries, timeout=timeout,
+                         axapi_args=kwargs)

--- a/acos_client/v30/slb/service_group.py
+++ b/acos_client/v30/slb/service_group.py
@@ -52,7 +52,7 @@ class ServiceGroup(base.BaseV30):
 
     def _set(self, name, protocol=None, lb_method=None, service_group_templates=None,
              hm_name=None, mem_list=None, health_check_disable=False, health_check=None,
-             **kwargs):
+             hm_delete=False, **kwargs):
 
         # Normalize "" -> None for json
         hm_name = hm_name or None
@@ -76,8 +76,8 @@ class ServiceGroup(base.BaseV30):
         if hm_name is None:
             params["service-group"]["health-check-disable"] = health_check_disable
             # Have to explicitly detach health monitor from the service group,
-            # by setting health_check parameter to None.
-            if health_check:
+            # by setting hm_delete flag
+            if hm_delete:
                 params["service-group"]["health-check"] = health_check
         else:
             params["service-group"]["health-check"] = hm_name
@@ -142,11 +142,11 @@ class ServiceGroup(base.BaseV30):
     def update(self, name, protocol=None, lb_method=None, health_monitor=None,
                service_group_templates=None, mem_list=None, hm_name=None,
                max_retries=None, timeout=None, health_check_disable=False, health_check=None,
-               **kwargs):
+               hm_delete=False, **kwargs):
         params = self._set(name, protocol=None, lb_method=lb_method, hm_name=hm_name,
                            service_group_templates=service_group_templates,
                            mem_list=mem_list, health_check_disable=health_check_disable,
-                           health_check=health_check, **kwargs)
+                           health_check=health_check, hm_delete=hm_delete, **kwargs)
         return self._post(self.url_prefix + name, params, max_retries=max_retries, timeout=timeout,
                           axapi_args=kwargs)
 

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import six
 
-
+import acos_client
 from acos_client import errors as ae
 from acos_client.v30 import base
 
@@ -175,6 +175,12 @@ class VirtualPort(base.BaseV30):
         aflex_scripts = kwargs.get("aflex-scripts", None)
         if aflex_scripts is not None:
             params['port']['aflex-scripts'] = aflex_scripts
+
+        # put options from flavor (and conf)
+        options = {}
+        options['port'] = self.dict_underscore_to_dash(kwargs.pop('virtual_port', None))
+        if options['port']:
+            params = acos_client.v21.axapi_http.merge_dicts(params, options)
 
         if update:
             url += self.url_port_tmpl.format(

--- a/acos_client/v30/slb/virtual_server.py
+++ b/acos_client/v30/slb/virtual_server.py
@@ -13,7 +13,6 @@
 #    under the License.
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import six
 
 from acos_client.v30 import base
 from acos_client.v30.slb.virtual_port import VirtualPort
@@ -34,7 +33,7 @@ class VirtualServer(base.BaseV30):
 
     def _set(self, name, ip_address=None, arp_disable=False, description=None, vrid=None,
              virtual_server_templates=None, template_virtual_server=None,
-             port_list=None, **kwargs):
+             port_list=None, status=None, **kwargs):
         params = {
             "virtual-server": self.minimal_dict({
                 "name": name,
@@ -68,47 +67,46 @@ class VirtualServer(base.BaseV30):
         if template_virtual_server:
             params['virtual-server']['template-virtual-server'] = str(template_virtual_server)
 
-        config_defaults = kwargs.get("config_defaults")
-        if config_defaults:
-            for k, v in six.iteritems(config_defaults):
-                params['virtual-server'][k] = v
-
         return params
 
     def create(self, name, ip_address, arp_disable=False, description=None, vrid=None,
                virtual_server_templates=None, template_virtual_server=None,
-               port_list=None, **kwargs):
+               port_list=None, max_retries=None, timeout=None, status=None, **kwargs):
         params = self._set(name, ip_address, arp_disable=arp_disable, description=description,
                            vrid=vrid, virtual_server_templates=virtual_server_templates,
                            template_virtual_server=template_virtual_server,
-                           port_list=port_list, **kwargs)
-        return self._post(self.url_prefix, params, **kwargs)
+                           port_list=port_list, status=status, **kwargs)
+        return self._post(self.url_prefix, params, max_retries=max_retries, timeout=timeout, axapi_args=kwargs)
 
     def update(self, name, ip_address=None, arp_disable=False, description=None, vrid=None,
                virtual_server_templates=None, template_virtual_server=None,
-               port_list=None, **kwargs):
+               port_list=None, max_retries=None, timeout=None, status=None, **kwargs):
         params = self._set(name, ip_address, arp_disable=arp_disable, description=description,
                            vrid=vrid, virtual_server_templates=virtual_server_templates,
                            template_virtual_server=template_virtual_server,
-                           port_list=port_list, **kwargs)
-        return self._post(self.url_prefix + name, params, **kwargs)
+                           port_list=port_list, status=status, **kwargs)
+        return self._post(self.url_prefix + name, params, max_retries=max_retries, timeout=timeout,
+                          axapi_args=kwargs)
 
     def replace(self, name, ip_address=None, arp_disable=False, description=None, vrid=None,
                 virtual_server_templates=None, template_virtual_server=None,
-                port_list=None, **kwargs):
+                port_list=None, max_retries=None, timeout=None, status=None, **kwargs):
         params = self._set(name, ip_address, arp_disable=arp_disable, description=description,
                            vrid=vrid, virtual_server_templates=virtual_server_templates,
                            template_virtual_server=template_virtual_server,
-                           port_list=port_list, **kwargs)
-        return self._put(self.url_prefix + name, params, **kwargs)
+                           port_list=port_list, status=status, **kwargs)
+        return self._put(self.url_prefix + name, params, max_retries=max_retries, timeout=timeout,
+                         axapi_args=kwargs)
 
     def delete(self, name):
         return self._delete(self.url_prefix + name)
 
-    def stats(self, name='', **kwargs):
-        resp = self._get(self.url_prefix + name + '/port/stats', **kwargs)
+    def stats(self, name='', max_retries=None, timeout=None, **kwargs):
+        resp = self._get(self.url_prefix + name + '/port/stats', max_retries=max_retries,
+                         timeout=timeout, axapi_args=kwargs)
         return resp
 
-    def oper(self, name='', **kwargs):
-        resp = self._get(self.url_prefix + name + '/oper', **kwargs)
+    def oper(self, name='', max_retries=None, timeout=None, **kwargs):
+        resp = self._get(self.url_prefix + name + '/oper', max_retries=max_retries,
+                         timeout=timeout, axapi_args=kwargs)
         return resp


### PR DESCRIPTION
This patch contains:
 - flavor support feature
 - STACK-1712 Write data migration scripts to go from a10-neutron-lbaas to octavia

Please check detail feature description, testing document in a10-octavia PR:
https://github.com/a10networks/a10-octavia/pull/251