### PR TITLE
Issue/stack 1988 [l7policy_degrade] cannot delete l7policy with action REJECT

### DIFF
--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -204,8 +204,8 @@ class VirtualPort(base.BaseV30):
     ):
 
         # backward compatiable for a10-neutron-lbaas
-        if not aflex_scripts:
-            aflex_scripts = kwargs.pop('aflex-scripts', None)
+        if aflex_scripts is None and 'aflex-scripts' in kwargs:
+            aflex_scripts = kwargs.pop('aflex-scripts')
 
         url, params, kwargs = self._set(
             virtual_server_name,
@@ -415,8 +415,8 @@ class VirtualPort(base.BaseV30):
     ):
 
         # backward compatiable for a10-neutron-lbaas
-        if not aflex_scripts:
-            aflex_scripts = kwargs.pop('aflex-scripts', None)
+        if aflex_scripts is None and 'aflex-scripts' in kwargs:
+            aflex_scripts = kwargs.pop('aflex-scripts')
 
         url, params, kwargs = self._update(
             virtual_server_name,

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -356,8 +356,8 @@ class VirtualPort(base.BaseV30):
     ):
 
         # backward compatiable for a10-neutron-lbaas
-        if not aflex_scripts:
-            aflex_scripts = kwargs.pop('aflex-scripts', None)
+        if aflex_scripts is None and 'aflex-scripts' in kwargs:
+            aflex_scripts = kwargs.pop('aflex-scripts')
 
         url, params, kwargs = self._update(
             virtual_server_name,


### PR DESCRIPTION
## Description
Severity Level: HIGH
Desciption: Can't l7policy delete the latest l7policy on load_balancer.

It is a degrade for previous change on virtual_port.py in acos-client. Previously aflex-scripts is in kwargs (as aflex-scripts) but now it is a named parameter (as aflex_scripts) in acos-client. And for backward compatible I add a check to use aflex-scripts in kwargs if aflex_scripts is not set. But didn't write it correctly. So, for empty list case it will match the condition and goes wrong.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1988


## Technical Approach
Use 'if aflex_scripts is None' instead in condition check. So, for aflex_scripts = [] case, it will not match the condition.
[optional] just remove this condition and backward compatible.

## Config Changes
This bug is not related to configuration

<pre>
<b>N/A</b>
</pre>

## Test Cases
1. create l7policy
2. delete l7policy, and check the latest l7policy can be deleted on thunder and openstack.

## Manual Testing
```
openstack loadbalancer l7policy create --action REDIRECT_TO_URL --redirect-url "http://test.com" --name policy11_1 vport1
openstack loadbalancer l7policy delete policy11_1
```


