### PR TITLE
Issue/stack 1970 acos5 not allow ha-conn-mirror for HTTP/HTTPS

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_virtual_port.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_port.py
@@ -34,6 +34,7 @@ AUTH_URL = '{}/auth'.format(BASE_URL)
 VSERVER_NAME = 'test'
 CREATE_URL = '{}/slb/virtual-server/{}/port/'.format(BASE_URL, VSERVER_NAME)
 OBJECT_URL = '{}/slb/virtual-server/{}/port/80+http'.format(BASE_URL, VSERVER_NAME)
+OBJECT_TCP_URL = '{}/slb/virtual-server/{}/port/80+tcp'.format(BASE_URL, VSERVER_NAME)
 ALL_URL = '{}/slb/virtual-server/{}/port/'.format(BASE_URL, VSERVER_NAME)
 OK_RESP = {'response': {'status': 'OK'}}
 
@@ -84,7 +85,6 @@ class TestVirtualPort(unittest.TestCase):
                 'port-number': 80,
                 'protocol': 'http',
                 'service-group': 'pool1',
-                'ha-conn-mirror': 1,
                 'no-dest-nat': 1,
                 'conn-limit': 50000,
                 'tcp_template': 'test_tcp_template',
@@ -122,6 +122,58 @@ class TestVirtualPort(unittest.TestCase):
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
     @responses.activate
+    def test_tcp_virtual_port_create_with_params(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        responses.add(responses.POST, CREATE_URL, json=OK_RESP, status=200)
+        params = {
+            'port':
+            {
+                'auto': 1,
+                'extended-stats': 1,
+                'ipinip': 1,
+                'name': 'test1_VPORT',
+                'pool': 'test_nat_pool',
+                'port-number': 80,
+                'protocol': 'tcp',
+                'service-group': 'pool1',
+                'ha-conn-mirror': 1,
+                'no-dest-nat': 1,
+                'conn-limit': 50000,
+                'tcp_template': 'test_tcp_template',
+                'template-persist-cookie': 'test_c_pers_template',
+                'template-persist-source-ip': 'test_s_pers_template',
+                'udp_template': 'test_udp_template',
+                'use-rcv-hop-for-resp': 1
+            }
+        }
+
+        resp = self.client.slb.virtual_server.vport.create(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.TCP,
+            protocol_port='80',
+            service_group_name='pool1',
+            s_pers_name="test_s_pers_template",
+            c_pers_name="test_c_pers_template",
+            ha_conn_mirror=1,
+            no_dest_nat=1,
+            conn_limit=50000,
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            source_nat_pool="test_nat_pool",
+            tcp_template="test_tcp_template",
+            udp_template="test_udp_template",
+            use_rcv_hop=True,
+        )
+
+        self.assertEqual(resp, OK_RESP)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @responses.activate
     def test_virtual_port_create_with_kwargs(self):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         responses.add(responses.POST, CREATE_URL, json=OK_RESP, status=200)
@@ -136,7 +188,6 @@ class TestVirtualPort(unittest.TestCase):
                 'port-number': 80,
                 'protocol': 'http',
                 'service-group': 'pool1',
-                'ha-conn-mirror': 1,
                 'no-dest-nat': 1,
                 'conn-limit': 400,
                 'use-rcv-hop-for-resp': 1
@@ -150,6 +201,53 @@ class TestVirtualPort(unittest.TestCase):
             virtual_server_name=VSERVER_NAME,
             name='test1_VPORT',
             protocol=self.client.slb.virtual_server.vport.HTTP,
+            protocol_port='80',
+            service_group_name='pool1',
+            ha_conn_mirror=1,
+            no_dest_nat=1,
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            source_nat_pool="test_nat_pool",
+            use_rcv_hop=True,
+            **kwargs
+        )
+
+        self.assertEqual(resp, OK_RESP)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, CREATE_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @responses.activate
+    def test_tcp_virtual_port_create_with_kwargs(self):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        responses.add(responses.POST, CREATE_URL, json=OK_RESP, status=200)
+        params = {
+            'port':
+            {
+                'auto': 1,
+                'extended-stats': 1,
+                'ipinip': 1,
+                'name': 'test1_VPORT',
+                'pool': 'test_nat_pool',
+                'port-number': 80,
+                'protocol': 'tcp',
+                'service-group': 'pool1',
+                'ha-conn-mirror': 1,
+                'no-dest-nat': 1,
+                'conn-limit': 400,
+                'use-rcv-hop-for-resp': 1
+            }
+        }
+        kwargs = {
+            'conn_limit': 400,
+        }
+
+        resp = self.client.slb.virtual_server.vport.create(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.TCP,
             protocol_port='80',
             service_group_name='pool1',
             ha_conn_mirror=1,
@@ -383,7 +481,6 @@ class TestVirtualPort(unittest.TestCase):
                 'port-number': 80,
                 'protocol': 'http',
                 'service-group': 'pool1',
-                'ha-conn-mirror': 1,
                 'conn-limit': 50000,
                 'tcp_template': 'test_tcp_template',
                 'template-persist-cookie': 'test_c_pers_template',
@@ -420,6 +517,60 @@ class TestVirtualPort(unittest.TestCase):
 
     @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
     @responses.activate
+    def test_tcp_virtual_port_update_with_params(self, mocked_get):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        mocked_get.return_value = {"foo": "bar"}
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, OBJECT_TCP_URL, json=json_response, status=200)
+        params = {
+            'port':
+            {
+                'auto': 1,
+                'extended-stats': 1,
+                'name': 'test1_VPORT',
+                'ipinip': 1,
+                'no-dest-nat': 1,
+                'pool': 'test_nat_pool',
+                'port-number': 80,
+                'protocol': 'tcp',
+                'service-group': 'pool1',
+                'ha-conn-mirror': 1,
+                'conn-limit': 50000,
+                'tcp_template': 'test_tcp_template',
+                'template-persist-cookie': 'test_c_pers_template',
+                'template-persist-source-ip': 'test_s_pers_template',
+                'udp_template': 'test_udp_template',
+                'use-rcv-hop-for-resp': 1,
+            }
+        }
+
+        resp = self.client.slb.virtual_server.vport.update(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.TCP,
+            protocol_port='80',
+            service_group_name='pool1',
+            s_pers_name="test_s_pers_template",
+            c_pers_name="test_c_pers_template",
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            ha_conn_mirror=1,
+            no_dest_nat=1,
+            conn_limit=50000,
+            source_nat_pool="test_nat_pool",
+            tcp_template="test_tcp_template",
+            udp_template="test_udp_template",
+            use_rcv_hop=True,
+        )
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_TCP_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
+    @responses.activate
     def test_virtual_port_update_with_kwargs(self, mocked_get):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         mocked_get.return_value = {"foo": "bar"}
@@ -437,7 +588,6 @@ class TestVirtualPort(unittest.TestCase):
                 'port-number': 80,
                 'protocol': 'http',
                 'service-group': 'pool1',
-                'ha-conn-mirror': 1,
                 'conn-limit': 400,
                 'template-persist-cookie': 'test_c_pers_template',
                 'template-persist-source-ip': 'test_s_pers_template',
@@ -493,7 +643,6 @@ class TestVirtualPort(unittest.TestCase):
                     'port-number': 80,
                     'protocol': 'http',
                     'service-group': 'pool1',
-                    'ha-conn-mirror': 1,
                     'conn-limit': 50000,
                     'tcp_template': 'test_tcp_template',
                     'template-persist-cookie': 'test_c_pers_template',
@@ -555,6 +704,63 @@ class TestVirtualPort(unittest.TestCase):
 
     @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
     @responses.activate
+    def test_tcp_virtual_port_update_with_templates(self, mocked_get):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        mocked_get.return_value = {"foo": "bar"}
+        json_response = {"foo": "bar"}
+        responses.add(responses.POST, OBJECT_TCP_URL, json=json_response, status=200)
+        params = {
+            'port':
+            {
+                'auto': 1,
+                'extended-stats': 1,
+                'name': 'test1_VPORT',
+                'ipinip': 1,
+                'no-dest-nat': 0,
+                'use-rcv-hop-for-resp': 0,
+                'pool': 'test_nat_pool',
+                'port-number': 80,
+                'protocol': 'tcp',
+                'service-group': 'pool1',
+                'ha-conn-mirror': 1,
+                'conn-limit': 50000,
+                'tcp_template': 'test_tcp_template',
+                'template-persist-cookie': 'test_c_pers_template',
+                'template-persist-source-ip': 'test_s_pers_template',
+                'udp_template': 'test_udp_template',
+                'template-virtual-port': 'template_vp'
+            }
+        }
+        resp = self.client.slb.virtual_server.vport.update(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.TCP,
+            protocol_port='80',
+            service_group_name='pool1',
+            s_pers_name="test_s_pers_template",
+            c_pers_name="test_c_pers_template",
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            ha_conn_mirror=1,
+            no_dest_nat=0,
+            conn_limit=50000,
+            source_nat_pool="test_nat_pool",
+            tcp_template="test_tcp_template",
+            udp_template="test_udp_template",
+            virtual_port_templates={
+                'template-virtual-port': 'template_vp'
+            },
+            use_rcv_hop=False,
+        )
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.POST)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_TCP_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
+    @responses.activate
     def test_virtual_port_replace_with_params(self, mocked_get):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         mocked_get.return_value = {"foo": "bar"}
@@ -572,7 +778,6 @@ class TestVirtualPort(unittest.TestCase):
                 'port-number': 80,
                 'protocol': 'http',
                 'service-group': 'pool1',
-                'ha-conn-mirror': 1,
                 'conn-limit': 50000,
                 'tcp_template': 'test_tcp_template',
                 'template-persist-cookie': 'test_c_pers_template',
@@ -609,6 +814,60 @@ class TestVirtualPort(unittest.TestCase):
 
     @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
     @responses.activate
+    def test_tcp_virtual_port_replace_with_params(self, mocked_get):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        mocked_get.return_value = {"foo": "bar"}
+        json_response = {"foo": "bar"}
+        responses.add(responses.PUT, OBJECT_TCP_URL, json=json_response, status=200)
+        params = {
+            'port':
+            {
+                'auto': 1,
+                'extended-stats': 1,
+                'name': 'test1_VPORT',
+                'ipinip': 1,
+                'no-dest-nat': 1,
+                'pool': 'test_nat_pool',
+                'port-number': 80,
+                'protocol': 'tcp',
+                'service-group': 'pool1',
+                'ha-conn-mirror': 1,
+                'conn-limit': 50000,
+                'tcp_template': 'test_tcp_template',
+                'template-persist-cookie': 'test_c_pers_template',
+                'template-persist-source-ip': 'test_s_pers_template',
+                'udp_template': 'test_udp_template',
+                'use-rcv-hop-for-resp': 1,
+            }
+        }
+
+        resp = self.client.slb.virtual_server.vport.replace(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.TCP,
+            protocol_port='80',
+            service_group_name='pool1',
+            s_pers_name="test_s_pers_template",
+            c_pers_name="test_c_pers_template",
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            ha_conn_mirror=1,
+            no_dest_nat=1,
+            conn_limit=50000,
+            source_nat_pool="test_nat_pool",
+            tcp_template="test_tcp_template",
+            udp_template="test_udp_template",
+            use_rcv_hop=True,
+        )
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.PUT)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_TCP_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
+    @responses.activate
     def test_virtual_port_replace_with_templates(self, mocked_get):
         responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
         mocked_get.return_value = {"foo": "bar"}
@@ -629,7 +888,6 @@ class TestVirtualPort(unittest.TestCase):
                     'port-number': 80,
                     'protocol': 'http',
                     'service-group': 'pool1',
-                    'ha-conn-mirror': 1,
                     'conn-limit': 50000,
                     'tcp_template': 'test_tcp_template',
                     'template-persist-cookie': 'test_c_pers_template',
@@ -687,6 +945,63 @@ class TestVirtualPort(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.PUT)
         self.assertEqual(responses.calls[1].request.url, OBJECT_URL)
+        self.assertEqual(json.loads(responses.calls[1].request.body), params)
+
+    @mock.patch('acos_client.v30.slb.virtual_port.VirtualPort.get')
+    @responses.activate
+    def test_tcp_virtual_port_replace_with_templates(self, mocked_get):
+        responses.add(responses.POST, AUTH_URL, json={'session_id': 'foobar'})
+        mocked_get.return_value = {"foo": "bar"}
+        json_response = {"foo": "bar"}
+        responses.add(responses.PUT, OBJECT_TCP_URL, json=json_response, status=200)
+        params = {
+            'port':
+            {
+                'auto': 1,
+                'extended-stats': 1,
+                'name': 'test1_VPORT',
+                'ipinip': 1,
+                'no-dest-nat': 0,
+                'use-rcv-hop-for-resp': 0,
+                'pool': 'test_nat_pool',
+                'port-number': 80,
+                'protocol': 'tcp',
+                'service-group': 'pool1',
+                'ha-conn-mirror': 1,
+                'conn-limit': 50000,
+                'tcp_template': 'test_tcp_template',
+                'template-persist-cookie': 'test_c_pers_template',
+                'template-persist-source-ip': 'test_s_pers_template',
+                'udp_template': 'test_udp_template',
+                'template-virtual-port': 'template_vp'
+            }
+        }
+        resp = self.client.slb.virtual_server.vport.replace(
+            virtual_server_name=VSERVER_NAME,
+            name='test1_VPORT',
+            protocol=self.client.slb.virtual_server.vport.TCP,
+            protocol_port='80',
+            service_group_name='pool1',
+            s_pers_name="test_s_pers_template",
+            c_pers_name="test_c_pers_template",
+            status=1,
+            autosnat=True,
+            ipinip=True,
+            ha_conn_mirror=1,
+            no_dest_nat=0,
+            conn_limit=50000,
+            source_nat_pool="test_nat_pool",
+            tcp_template="test_tcp_template",
+            udp_template="test_udp_template",
+            virtual_port_templates={
+                'template-virtual-port': 'template_vp'
+            },
+            use_rcv_hop=False,
+        )
+        self.assertEqual(resp, json_response)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[1].request.method, responses.PUT)
+        self.assertEqual(responses.calls[1].request.url, OBJECT_TCP_URL)
         self.assertEqual(json.loads(responses.calls[1].request.body), params)
 
     @responses.activate

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -205,8 +205,8 @@ class VirtualPort(base.BaseV30):
     ):
 
         # backward compatiable for a10-neutron-lbaas
-        if aflex_scripts is None and 'aflex-scripts' in kwargs:
-            aflex_scripts = kwargs.pop('aflex-scripts')
+        if not aflex_scripts:
+            aflex_scripts = kwargs.pop('aflex-scripts', None)
 
         url, params, kwargs = self._set(
             virtual_server_name,
@@ -357,8 +357,8 @@ class VirtualPort(base.BaseV30):
     ):
 
         # backward compatiable for a10-neutron-lbaas
-        if aflex_scripts is None and 'aflex-scripts' in kwargs:
-            aflex_scripts = kwargs.pop('aflex-scripts')
+        if not aflex_scripts:
+            aflex_scripts = kwargs.pop('aflex-scripts', None)
 
         url, params, kwargs = self._update(
             virtual_server_name,
@@ -416,8 +416,8 @@ class VirtualPort(base.BaseV30):
     ):
 
         # backward compatiable for a10-neutron-lbaas
-        if aflex_scripts is None and 'aflex-scripts' in kwargs:
-            aflex_scripts = kwargs.pop('aflex-scripts')
+        if not aflex_scripts:
+            aflex_scripts = kwargs.pop('aflex-scripts', None)
 
         url, params, kwargs = self._update(
             virtual_server_name,

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -204,8 +204,8 @@ class VirtualPort(base.BaseV30):
     ):
 
         # backward compatiable for a10-neutron-lbaas
-        if not aflex_scripts:
-            aflex_scripts = kwargs.pop('aflex-scripts', None)
+        if aflex_scripts is None and 'aflex-scripts' in kwargs:
+            aflex_scripts = kwargs.pop('aflex-scripts')
 
         url, params, kwargs = self._set(
             virtual_server_name,
@@ -415,8 +415,8 @@ class VirtualPort(base.BaseV30):
     ):
 
         # backward compatiable for a10-neutron-lbaas
-        if not aflex_scripts:
-            aflex_scripts = kwargs.pop('aflex-scripts', None)
+        if aflex_scripts is None and 'aflex-scripts' in kwargs:
+            aflex_scripts = kwargs.pop('aflex-scripts')
 
         url, params, kwargs = self._update(
             virtual_server_name,

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -356,8 +356,8 @@ class VirtualPort(base.BaseV30):
     ):
 
         # backward compatiable for a10-neutron-lbaas
-        if not aflex_scripts:
-            aflex_scripts = kwargs.pop('aflex-scripts', None)
+        if aflex_scripts is None and 'aflex-scripts' in kwargs:
+            aflex_scripts = kwargs.pop('aflex-scripts')
 
         url, params, kwargs = self._update(
             virtual_server_name,

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -159,7 +159,8 @@ class VirtualPort(base.BaseV30):
         if no_dest_nat is not None:
             params["port"]["no-dest-nat"] = 1 if no_dest_nat else 0
         if ha_conn_mirror is not None:
-            params["port"]["ha-conn-mirror"] = 1 if ha_conn_mirror else 0
+            if (protocol == self.TCP or protocol == self.UDP):
+                params["port"]["ha-conn-mirror"] = 1 if ha_conn_mirror else 0
         if conn_limit is not None:
             params["port"]["conn-limit"] = conn_limit
 


### PR DESCRIPTION
## Description
Severity Level: Medium
Desciption: ACOS5 didn't allow ha-conn-mirror for HTTP, HTTPS and TERMINATED_HTTPS.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1970

## Technical Approach
ACOS5 didn't allow ha-conn-mirror for HTTP, HTTPS and TERMINATED_HTTPS. So,
 - For TCP/UDP, listener will created with ha-conn-mirror
 - For HTTP/HTTPS and TERMINATED_HTTPS, listener will be created correctly but without ha-conn-mirror

## Config Changes
<pre>
<b>
[a10_controller_worker]
network_driver = a10_octavia_neutron_driver

[listener]
autosnat = True
conn_limit=555000
ha_conn_mirror=True

[health_monitor]
post_data = "abc=1"

[hardware_thunder]
devices = [
                    {
                     "project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "ytsai-Thunder"
                     }
             ]

</b>
</pre>

## Test Cases
1. create listener with http
2. create listener with tcp
3. only tcp listener will have ha-conn-mirror. HTTP will not have ha-conn-mirror but can create successfully.

## Manual Testing
```
openstack loadbalancer create --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1

openstack loadbalancer listener create --protocol tcp --protocol-port 81 --name vport1 vip1
```

Result:
```
slb virtual-server dc5c932d-4d79-41a7-8592-9e09830e9578 192.168.91.56
  port 80 http
    name dbbe3d9f-1f83-417f-97b2-33e91850c9f6
    conn-limit 555000
    extended-stats
    source-nat auto
  port 81 tcp
    name c25deb38-5808-4bad-9150-2ea74cc4ecb2
    conn-limit 555000
    ha-conn-mirror
    extended-stats
    source-nat auto
!
```
