### PR TITLE
Issue/stack 1979 [healthmonitor_degrade] failed to create hm with protcol type TCP or UDP-CONNECT

### DIFF
--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -94,8 +94,10 @@ class HealthMonitor(base.BaseV30):
                 k = '%s-port' % mon_method
             params['monitor']['method'][mon_method][k] = int(port)
             params['monitor']['override-port'] = int(port)
-        # handle POST case
-        if params['monitor']['method'][mon_method]['url-type'] == "POST":
+        # handle POST case for HTTP/HTTPS hm
+        if ('url-type' in params['monitor']['method'][mon_method] and
+                'url-path' in params['monitor']['method'][mon_method] and
+                params['monitor']['method'][mon_method]['url-type'] == "POST"):
             if post_data:
                 params['monitor']['method'][mon_method]['post-type'] = "postdata"
                 params['monitor']['method'][mon_method]['http-postdata'] = str(post_data)


### PR DESCRIPTION
## Description
Severity Level: HIGH
Desciption: HM creation failed for TCP and UDP-CONNECT type

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1979

## Technical Approach
It is degraded by STACK-1654, in patch of STACK-1654 didn't consider TCP and UDP-CONNECT types.
So, this patch we will check url-type and url-path before using it in directory. Because TCP and UDP-CONNECT will not have these keys in directory.

## Config Changes
<pre>
<b>
[a10_controller_worker]
network_driver = a10_octavia_neutron_driver

[listener]
autosnat = True
conn_limit=555000
ha_conn_mirror=True

[health_monitor]
post_data = "abc=1"

[hardware_thunder]
devices = [
                    {
                     "project_id": "3d21c71c4e4040599933bda62a76ae2f",
                     "ip_address": "192.168.90.46",
                     "username": "admin",
                     "password": "a10",
                     "device_name": "ytsai-Thunder"
                     }
             ]
</b>
</pre>

## Test Cases
1. create hm for TCP
2. create hm for UDP
3. create hm for HTTP with POST method
4. all hm should create correctly.

## Manual Testing
```
openstack loadbalancer create --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol TCP --protocol-port 80 --name vport1 vip1
openstack loadbalancer listener create --protocol UDP --protocol-port 53 --name vport2 vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 8080 --name vport3 vip1
openstack loadbalancer pool create --protocol TCP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer pool create --protocol UDP --lb-algorithm ROUND_ROBIN --listener vport2 --name sg2
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport3 --name sg3
openstack loadbalancer healthmonitor  create --delay 7 --timeout 6 --max-retries 3 --type TCP sg1 --name hm1
openstack loadbalancer healthmonitor  create --delay 7 --timeout 6 --max-retries 3 --type UDP-CONNECT sg2 --name hm2
openstack loadbalancer healthmonitor create --delay 3 --timeout 3 --max-retries 2 --http-method POST --type HTTP  sg3 --name hm3
openstack loadbalancer healthmonitor set --max-retries 5 hm3
```

Result:
```
health monitor c9ca2bd9-024d-426d-9885-335234fd8464
  override-port 80
  interval 7 timeout 6
  method tcp port 80
!
health monitor 277846a0-6b22-4859-bb44-157410fc6e1a
  override-port 53
  interval 7 timeout 6
  method udp port 53
!
health monitor a3eb83a8-a24e-4b41-ae70-b7c652d4ed5a
  retry 5
  override-port 8080
  interval 3 timeout 3
  method http port 8080 expect response-code 200 url POST / postdata abc=1
!
slb service-group 53a4f9a9-29d1-471b-a2d9-124bef9d9a66 udp
  health-check 277846a0-6b22-4859-bb44-157410fc6e1a
!
slb service-group d91d7bff-523e-47b7-aac7-eae11b9cd28e tcp
  health-check c9ca2bd9-024d-426d-9885-335234fd8464
!
slb service-group e7cf15c7-3b84-4f52-82df-1a02deda4f1e tcp
  health-check a3eb83a8-a24e-4b41-ae70-b7c652d4ed5a
!
slb virtual-server dc5c932d-4d79-41a7-8592-9e09830e9578 192.168.91.56
  port 53 udp
    name 8c111a74-05c9-4cf4-8225-ca9078569001
    conn-limit 555000
    ha-conn-mirror
    extended-stats
    source-nat auto
    service-group 53a4f9a9-29d1-471b-a2d9-124bef9d9a66
  port 80 tcp
    name fd0dd156-51b8-4ec8-a041-726cd9895120
    conn-limit 555000
    ha-conn-mirror
    extended-stats
    source-nat auto
    service-group d91d7bff-523e-47b7-aac7-eae11b9cd28e
  port 8080 http
    name 5eb2bfff-7e18-4b37-bcf4-10554175095e
    conn-limit 555000
    extended-stats
    source-nat auto
    service-group e7cf15c7-3b84-4f52-82df-1a02deda4f1e
!
```
