### PR TITLE
Issue/stack 1998 Bug config result is wrong if added "response-code-regex" in flavor

### DIFF
--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -107,6 +107,14 @@ class HealthMonitor(base.BaseV30):
             params['monitor']['method'][mon_method].pop('http-postdata', None)
             params['monitor']['method'][mon_method].pop('post-path', None)
 
+        # 'response-code-regex' is conflict with 'http-response-code', so if flavor
+        # contains 'response-code-regex' we should remove 'http-response-code'
+        if 'http-response-code' in params['monitor']['method'][mon_method]:
+            if ('monitor' in kwargs and 'method' in kwargs['monitor'] and
+               mon_method in kwargs['monitor']['method'] and
+               'response_code_regex' in kwargs['monitor']['method'][mon_method]):
+                params['monitor']['method'][mon_method].pop('http-response-code')
+
         return params
 
     def create(self, name, mon_type, hm_interval, hm_timeout, hm_max_retries,


### PR DESCRIPTION
## Description
- Severity Level: Low
- Issue Description:
When 'response-code-regex' in hm flavor, thunder can't configure correctly for hm.

[Notice] This priority is low, because in our original design our plan is not to check axapi arguments and let user to maintain it.
User should able to use flowing flavor to prevent this issue:
```
openstack loadbalancer flavorprofile create --name fp_hm_http_get2 --provider a10 --flavor-data '{"health-monitor": {"retry":5, "interval":7,"timeout":7, "method": { "http": { "http":1, "http-expect":1, "http-response-code": null, "response-code-regex":"20[0-5]", "http-url":1, "url-type":"GET", "url-path":"/abc"}}}}'
```

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1998

## Technical Approach
In acos-client, if user has 'response-code-regex' in flavor. We will remove 'http-response-code' in parameter. Since they are conflict and flavor has higher priority.


## Config Changes
- Example flavor
<pre>
<b>
{"health-monitor": {"retry":5, "interval":7,"timeout":7, "method": { "http": { "http":1, "http-expect":1, "response-code-regex":"20[0-5]", "http-url":1, "url-type":"GET", "url-path":"/abc"}}}}
</b>
</pre>


## Test Cases
1.  Rum same commands as STACK-1998
2. result is fine

## Manual Testing
```
openstack loadbalancer flavorprofile create --name fp_hm_http_get2 --provider a10 --flavor-data '{"health-monitor": {"retry":5, "interval":7,"timeout":7, "method": { "http": { "http":1, "http-expect":1, "response-code-regex":"20[0-5]", "http-url":1, "url-type":"GET", "url-path":"/abc"}}}}'
openstack loadbalancer flavor create --name f_hm_http_get2 --flavorprofile fp_hm_http_get2

openstack loadbalancer create  --flavor f_hm_http_get2 --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer healthmonitor create --delay 30 --timeout 3 --max-retries 3 --type HTTP sg1 --name hm1
```

- result:
```
health monitor 0554e3ae-d85b-4f87-984d-f3a11f4ed5ac
  retry 5
  override-port 80
  interval 7 timeout 7
  method http port 80 expect response-code-regex 20[0-5] url GET /abc
!
```