### PR TITLE
[STACK-2025] Bug fix axapi URI for TERMINATED_HTTPS vport

### DIFF
--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -54,15 +54,18 @@ class VirtualPort(base.BaseV30):
     url_server_tmpl = '/slb/virtual-server/{name}/port/'
     url_port_tmpl = '{port_number}+{protocol}'
 
+    def format_vport_url(self, port_number, protocol):
+        if protocol == 'TERMINATED_HTTPS':
+            protocol = "https"
+        return self.url_port_tmpl.format(port_number=port_number, protocol=protocol)
+
     def all(self, virtual_server_name, **kwargs):
         url = self.url_server_tmpl.format(name=virtual_server_name)
         return self._get(url, **kwargs)
 
     def get(self, virtual_server_name, name, protocol, port):
         url = self.url_server_tmpl.format(name=virtual_server_name)
-        url += self.url_port_tmpl.format(
-            port_number=port, protocol=protocol
-        )
+        url += self.format_vport_url(port_number=port, protocol=protocol)
         return self._get(url)
 
     def _set(
@@ -170,9 +173,7 @@ class VirtualPort(base.BaseV30):
             params['port']['aflex-scripts'] = aflex_scripts
 
         if update:
-            url += self.url_port_tmpl.format(
-                port_number=protocol_port, protocol=protocol
-            )
+            url += self.format_vport_url(port_number=protocol_port, protocol=protocol)
         return url, params, kwargs
 
     def create(
@@ -447,7 +448,7 @@ class VirtualPort(base.BaseV30):
 
     def delete(self, virtual_server_name, name, protocol, port):
         url = self.url_server_tmpl.format(name=virtual_server_name)
-        url += self.url_port_tmpl.format(port_number=port, protocol=protocol)
+        url += self.format_vport_url(port_number=port, protocol=protocol)
         return self._delete(url)
 
     def _set_sampling_enable(self, sample_list, dest_obj):


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue description: For TERMINATED_HTTPS protocol listener, the protocol on Thunder vport is https. User TERMINATED_HTTPS as protocol in axapi URI Thunder can't find the vport instance on thunder.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2025

## Technical Approach
If protocol is TERMINATED_HTTPS, change to https in axapi URI.

## Config Changes

<pre>
<b>
{ 
    "nat-pool":{ 
        "pool-name":"pool1", 
        "start-address":"192.168.90.201", 
        "end-address":"192.168.90.210", 
        "netmask":"/24", 
        "gateway":"192.168.90.1" 
    }, 
    "nat-pool-list":[ 
        { 
            "pool-name":"pool2", 
            "start-address":"192.168.90.211", 
            "end-address":"192.168.90.220", 
            "netmask":"/24", 
            "gateway":"192.168.90.1" 
        }, 
        { 
            "pool-name":"pool3", 
            "start-address":"192.168.90.221", 
            "end-address":"192.168.90.230", 
            "netmask":"/24", 
            "gateway":"192.168.90.1" 
        } 
    ],
	"virtual-port": {
		“name-expressions": [
			{
				"regex": "vport2",
				"json": {"pool": "pool2"}
			},
		]
	}
}
</b>
</pre>

## Manual Testing

```
openstack loadbalancer flavorprofile create --name fp_snat_list --provider a10 --flavor-data '{"nat-pool":{"pool-name":"pool1", "start-address":"192.168.90.201", "end-address":"192.168.90.210", "netmask":"/24", "gateway":"192.168.90.1"}, "nat-pool-list":[{"pool-name":"pool2", "start-address":"192.168.90.211", "end-address":"192.168.90.220", "netmask":"/24", "gateway":"192.168.90.1"}, {"pool-name":"pool3", "start-address":"192.168.90.221", "end-address":"192.168.90.230", "netmask":"/24", "gateway":"192.168.90.1"}], "virtual-port": {"name-expressions": [{"regex": "vport2", "json": {"pool": "pool2"}}]}}'
openstack loadbalancer flavor create --name f_snat_list --flavorprofile fp_snat_list --description "flaovr all test1" --enable
openstack loadbalancer create --flavor f_snat_list --vip-subnet-id f25ce642-f953-4058-8c46-98fdd72fb129 --vip-address 192.168.91.56 --name vip1
openstack loadbalancer listener create  --protocol TERMINATED_HTTPS --default-tls-container-ref http://10.64.3.100/key-manager/v1/containers/e94299ce-bdfd-44b5-93fe-885418c1a863 --protocol-port 443 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vport1 --name sg1
openstack loadbalancer member create --address 192.168.90.132 --subnet-id tp90 --protocol-port 80 --name srv1 sg1
```

Thunder:
```
slb server 3d21c_192_168_90_132 192.168.90.132
  port 80 tcp
!
slb service-group 5cb6828c-e974-4a49-bbf1-694720d41050 tcp
  member 3d21c_192_168_90_132 80
!
slb template client-ssl 497e763a-2469-4723-8f23-467a49f6688d
  cert mycert
  key mykey
!
slb virtual-server 6306c1ab-ce84-4b3a-aad0-ca62c5c2c4b0 192.168.91.56
  port 443 https
    name 497e763a-2469-4723-8f23-467a49f6688d
    extended-stats
    source-nat pool pool1
    source-nat auto
    service-group 5cb6828c-e974-4a49-bbf1-694720d41050
    template client-ssl 497e763a-2469-4723-8f23-467a49f6688d
!
```
