### PR TITLE
[Bug][STACK-1514]: Removed default value from destination for write memory

### DIFF
--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -20,7 +20,7 @@ from acos_client.v30 import base
 
 class Action(base.BaseV30):
 
-    def write_memory(self, partition="all", destination="primary", specified_partition=None, **kwargs):
+    def write_memory(self, partition="all", destination=None, specified_partition=None, **kwargs):
         payload = {
             "memory": {
                 "destination": destination,
@@ -42,7 +42,7 @@ class Action(base.BaseV30):
             # If the retry loop missed this, catch it next time.
             pass
 
-    def activate_and_write(self, partition="all", destination="primary", **kwargs):
+    def activate_and_write(self, partition="all", destination=None, **kwargs):
         self.write_memory(partition, destination)
 
     def clideploy(self, commandlist, **kwargs):


### PR DESCRIPTION
## Description
- Severity Level: High
- Issue description: When we use `write_memory()` method without any argument, it sends configuration to Primary Configuration by default, which doesn't save `non-Default Profiles`. 

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-1514
https://a10networks.atlassian.net/browse/STACK-2024

## Technical Approach
- Set argument default value of `destination` as `None` instead of `primary` in `write_memory()` method.
http://acos.docs.a10networks.com/axapi/521/write_memory.html#memory-attributes

## Config Changes
None

## Manual Testing
```
c = acos.Client('10.0.0.81', acos.AXAPI_30, 'admin', 'a10')
# for shared partition
c.system.action.write_memory(partition="shared")
# for specific partition
c.system.action.write_memory(partition="specified", specified_partition="b8a9e31710ef4b")

```

Expected result : 
![image](https://user-images.githubusercontent.com/52992745/105030467-d837a480-5a79-11eb-885c-68c2f6973c75.png)


