### PR TITLE
feat (slb): allow add a slb server with FQDN

### DIFF
--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 
 from acos_client.v30 import base
 from acos_client.v30.slb.port import Port
-
+import validators
 
 class Server(base.BaseV30):
 
@@ -40,8 +40,10 @@ class Server(base.BaseV30):
 
         if port_list:
             params['server']['port-list'] = port_list
-
-        if self._is_ipv6(ip_address):
+        
+        if validators.domain(ip_address):
+            params['server']['fqdn-name'] = ip_address
+        elif self._is_ipv6(ip_address):
             params['server']['server-ipv6-addr'] = ip_address
         else:
             params['server']['host'] = ip_address

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.3.0
 six
 uhashring
 ipaddress==1.0.22; python_version < '3.0'
+validators


### PR DESCRIPTION
Hi,

we are adding a large amount of SLB severs with FQDN in our ADC environment and would like to automate this via the acos-client.

Currently, a SLB severs can only be added with IPv4 or IPv6 address. This PR fixes that. To validate the domain I used the `validators` module, because I find the regex variants all unsatisfactory.
