### PR TITLE
[STACK-2162] acos-client for victoria

### DIFF
--- a/acos_client/v21/axapi_http.py
+++ b/acos_client/v21/axapi_http.py
@@ -95,7 +95,7 @@ class HttpClient(object):
 
     def __init__(self, host, port=None, protocol="https", max_retries=3, timeout=5):
         if port is None:
-            if protocol is 'http':
+            if protocol == 'http':
                 self.port = 80
             else:
                 self.port = 443

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -39,7 +39,7 @@ class HttpClient(object):
 
     def __init__(self, host, port=None, protocol="https", max_retries=3, timeout=5):
         if port is None:
-            if protocol is 'http':
+            if protocol == 'http':
                 self.port = 80
             else:
                 self.port = 443

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.3.0
 six
-uhashring
+uhashring==1.2
 ipaddress==1.0.22; python_version < '3.0'


### PR DESCRIPTION
See also a10-octavia side changes:
https://github.com/a10networks/a10-octavia/pull/333


Result:
```shell
stack@ytsai-victoria:~/source/acos-client/victoria$ sudo tox -e py38
py38 develop-inst-noop: /opt/stack/source/acos-client/victoria
py38 installed: -e git+git@github.com:ytsai-a10/acos-client.git@291bab52a63819a917c4ec57a16a909be8b6595c#egg=acos_client,appdirs==1.4.3,CacheControl==0.12.6,certifi==2019.11.28,chardet==3.0.4,colorama==0.4.3,contextlib2==0.6.0,distlib==0.3.0,distro==1.4.0,flake8==2.2.4,hacking==0.10.3,html5lib==1.0.1,idna==2.8,ipaddr==2.2.0,lockfile==0.12.2,mccabe==0.2.1,msgpack==0.6.2,packaging==20.3,pbr==5.5.1,pep517==0.8.2,pep8==1.5.7,progress==1.5,pyflakes==0.8.1,pyparsing==2.4.6,pytoml==0.1.21,requests==2.25.1,responses==0.12.1,retrying==1.3.3,six==1.15.0,uhashring==2.0,urllib3==1.25.8,webencodings==0.5.1
py38 run-test-pre: PYTHONHASHSEED='42'
py38 run-test: commands[0] | python setup.py test -q
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing acos_client.egg-info/PKG-INFO
writing dependency_links to acos_client.egg-info/dependency_links.txt
writing requirements to acos_client.egg-info/requires.txt
writing top-level names to acos_client.egg-info/top_level.txt
reading manifest file 'acos_client.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'acos_client.egg-info/SOURCES.txt'
running build_ext
........................................................................................................................................................................................when RULE_INIT{ change }
..when RULE_INIT{}
......................................................................................................
----------------------------------------------------------------------
Ran 288 tests in 0.700s

OK
__________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________
  py38: commands succeeded
  congratulations :)
stack@ytsai-victoria:~/source/acos-client/victoria$ sudo tox -e ospep8
ospep8 develop-inst-noop: /opt/stack/source/acos-client/victoria
ospep8 installed: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support,-e git+git@github.com:ytsai-a10/acos-client.git@291bab52a63819a917c4ec57a16a909be8b6595c#egg=acos_client,appdirs==1.4.3,CacheControl==0.12.6,certifi==2019.11.28,chardet==3.0.4,colorama==0.4.3,contextlib2==0.6.0,cookies==2.2.1,distlib==0.3.0,distro==1.4.0,flake8==2.2.4,funcsigs==1.0.2,hacking==0.10.3,html5lib==1.0.1,idna==2.8,ipaddr==2.2.0,ipaddress==1.0.22,linecache2==1.0.0,lockfile==0.12.2,mccabe==0.2.1,mock==3.0.5,msgpack==0.6.2,packaging==20.3,pbr==5.5.1,pep517==0.8.2,pep8==1.5.7,progress==1.5,pyflakes==0.8.1,pyparsing==2.4.6,pytoml==0.1.21,requests==2.25.1,responses==0.12.1,retrying==1.3.3,six==1.15.0,traceback2==1.4.0,uhashring==1.2,unittest2==1.1.0,urllib3==1.25.8,webencodings==0.5.1
ospep8 run-test-pre: PYTHONHASHSEED='42'
ospep8 run-test: commands[0] | flake8
__________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________
  ospep8: commands succeeded
  congratulations :)

```