### PR TITLE
STACK[2015][Dynamic Interface Attachment]: Support dynamic interface attachment detection

### DIFF
--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -128,7 +128,7 @@ class Action(base.BaseV30):
         url = "/version/oper"
         return self._get(url)
 
-    def reload_reboot(self, acos_version=None):
+    def reload_reboot_for_interface_attachment(self, acos_version=None):
         if not acos_version:
             version_summary = self.get_acos_version()
             acos_version = version_summary['version']['oper']['sw-version'].split(',')[0]

--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -119,3 +119,11 @@ class Action(base.BaseV30):
     def get_thunder_up_time(self):
         url = "/miscellenious-alb/oper"
         return self._get(url)
+
+    def probe_network_devices(self):
+        url = "/system/probe-network-devices"
+        self._post(url)
+
+    def get_acos_version(self):
+        url = "/version/oper"
+        return self._get(url)

--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -127,3 +127,18 @@ class Action(base.BaseV30):
     def get_acos_version(self):
         url = "/version/oper"
         return self._get(url)
+
+    def reload_reboot(self, acos_version=None):
+        if not acos_version:
+            version_summary = self.get_acos_version()
+            acos_version = version_summary['version']['oper']['sw-version'].split(',')[0]
+
+        major = acos_version.split('.')[0]
+        minor = acos_version.split('.')[1]
+        patch = acos_version.split('.')[2]
+
+        if major >= 5 and minor >= 2 and patch >= 0:
+            self.probe_network_devices()
+            self.reload()
+        else:
+            self.reboot()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.3.0
 six
-uhashring
+uhashring==1.2
 ipaddress==1.0.22; python_version < '3.0'

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ install_command = pip install -U {opts} {packages}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
+    uhashring==1.2
 commands = python setup.py test -q {posargs}
-uhashring==1.2
 
 [testenv:pep8]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands = python setup.py test -q {posargs}
+uhashring==1.2
 
 [testenv:pep8]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ install_command = pip install -U {opts} {packages}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-    uhashring==1.2
 commands = python setup.py test -q {posargs}
 
 [testenv:pep8]


### PR DESCRIPTION
## Description:
- Added a method `probe_network_devices` to execute "system probe-network-devices" on vThunder.
- Added a method `get_acos_version` to get acos_version of a vThunder.

## Jira Ticket:
https://a10networks.atlassian.net/browse/STACK-2155

## Related PR:
https://github.com/a10networks/a10-octavia/pull/334