### PR TITLE
STACK-2015: Dynamic Interface Detachment Detection Support

### DIFF
--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -142,3 +142,18 @@ class Action(base.BaseV30):
             self.reload()
         else:
             self.reboot()
+
+    def reload_reboot_for_interface_detachment(self, acos_version=None):
+        if not acos_version:
+            version_summary = self.get_acos_version()
+            acos_version = version_summary['version']['oper']['sw-version'].split(',')[0]
+
+        major = acos_version.split('.')[0]
+        minor = acos_version.split('.')[1]
+        patch = acos_version.split('.')[2]
+
+        if major >= 5 and minor >= 2 and patch >= 1:
+            self.probe_network_devices()
+            self.reload()
+        else:
+            self.reboot()


### PR DESCRIPTION
## Description
Added API `reload_reboot_for_interface_detachment()` to perform reload/reboot on vthunder for interface detachment detection depending on the vthunder's acos_version

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2157
https://a10networks.atlassian.net/browse/STACK-2158