### PR TITLE
[Feature][STACK-2015][Dynamic Interface Detection]: Support for Dynamic Interface Detection after loadbalancers and members creation and deletion.

### DIFF
--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -142,3 +142,18 @@ class Action(base.BaseV30):
             self.reload()
         else:
             self.reboot()
+
+    def reload_reboot_for_interface_detachment(self, acos_version=None):
+        if not acos_version:
+            version_summary = self.get_acos_version()
+            acos_version = version_summary['version']['oper']['sw-version'].split(',')[0]
+
+        major = acos_version.split('.')[0]
+        minor = acos_version.split('.')[1]
+        patch = acos_version.split('.')[2]
+
+        if major >= 5 and minor >= 2 and patch >= 1:
+            self.probe_network_devices()
+            self.reload()
+        else:
+            self.reboot()

--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -119,3 +119,26 @@ class Action(base.BaseV30):
     def get_thunder_up_time(self):
         url = "/miscellenious-alb/oper"
         return self._get(url)
+
+    def probe_network_devices(self):
+        url = "/system/probe-network-devices"
+        self._post(url)
+
+    def get_acos_version(self):
+        url = "/version/oper"
+        return self._get(url)
+
+    def reload_reboot_for_interface_attachment(self, acos_version=None):
+        if not acos_version:
+            version_summary = self.get_acos_version()
+            acos_version = version_summary['version']['oper']['sw-version'].split(',')[0]
+
+        major = acos_version.split('.')[0]
+        minor = acos_version.split('.')[1]
+        patch = acos_version.split('.')[2]
+
+        if major >= 5 and minor >= 2 and patch >= 0:
+            self.probe_network_devices()
+            self.reload()
+        else:
+            self.reboot()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.3.0
 six
-uhashring
+uhashring==1.2
 ipaddress==1.0.22; python_version < '3.0'


### PR DESCRIPTION
## Description
Added following APIs to support dynamic interface attachment and detachment:

**get_acos_version()**:  For getting acos_version of the vThunder device

**probe_network_devices()** : For detecting the attached interfaces(for ACOS version >= 5.2.0) and detached interfaces(for ACOS version >= 5.2.1)

**reload_reboot_for_interface_attachment()**: For performing reload or reboot on vThunder depending on the ACOS version check during interface attachment.

**reload_reboot_for_interface_detachment()**: For performing reload or reboot on vThunder depending on the ACOS version check during interface detachment.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2015

## Related PR
https://github.com/a10networks/a10-octavia/pull/344