### PR TITLE
[STACK-2220] acos-client timeout too short

### DIFF
--- a/acos_client/tests/unit/v30/test_bladeparam.py
+++ b/acos_client/tests/unit/v30/test_bladeparam.py
@@ -83,21 +83,21 @@ class TestBlade(unittest.TestCase):
     def test_blade_get(self):
         self.target.get(0)
         self.client.http.request.assert_called_with("GET", self.url_prefix.format(0), {}, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_create(self):
         self.target.create(4)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
             self._expected_payload(), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_create_priority(self):
         self.target.create(4, 122)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
             self._expected_payload(122), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_create_interface(self):
         interface = self._build_interface()
@@ -107,7 +107,7 @@ class TestBlade(unittest.TestCase):
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
             self._expected_payload(interface=interface), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_create_gateway(self):
         gateway = self._build_ipv4gateway('1.1.1.1')
@@ -117,7 +117,7 @@ class TestBlade(unittest.TestCase):
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
             self._expected_payload(gateway=gateway), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_create_gateway_ipv6(self):
         gateway = self._build_ipv6gateway('1.1.1.1')
@@ -127,7 +127,7 @@ class TestBlade(unittest.TestCase):
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
             self._expected_payload(gateway=gateway), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_create_interface_gateway(self):
         interface = self._build_interface()
@@ -139,21 +139,21 @@ class TestBlade(unittest.TestCase):
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix.format(4),
             self._expected_payload(interface=interface, gateway=gateway), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_update(self):
         self.target.update(4)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
             self._expected_payload(), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_update_priority(self):
         self.target.update(4, 122)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
             self._expected_payload(122), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_update_interface(self):
         interface = self._build_interface()
@@ -163,7 +163,7 @@ class TestBlade(unittest.TestCase):
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
             self._expected_payload(interface=interface), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_update_gateway(self):
         gateway = self._build_ipv4gateway('1.1.1.1')
@@ -173,7 +173,7 @@ class TestBlade(unittest.TestCase):
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
             self._expected_payload(gateway=gateway), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_update_gateway_ipv6(self):
         gateway = self._build_ipv6gateway('1.1.1.1')
@@ -183,7 +183,7 @@ class TestBlade(unittest.TestCase):
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
             self._expected_payload(gateway=gateway), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_blade_update_interface_gateway(self):
         interface = self._build_interface()
@@ -195,4 +195,4 @@ class TestBlade(unittest.TestCase):
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix.format(4),
             self._expected_payload(interface=interface, gateway=gateway), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)

--- a/acos_client/tests/unit/v30/test_dns.py
+++ b/acos_client/tests/unit/v30/test_dns.py
@@ -38,7 +38,7 @@ class TestDns(unittest.TestCase):
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + 'primary',
                                                     expected_payload, mock.ANY, axapi_args=None,
-                                                    max_retries=None, timeout=None)
+                                                    max_retries=None, timeout=mock.ANY)
 
     def test_primary_ipv6(self):
         expected = '0:0:0:0:0:FFFF:129.144.52.38'
@@ -48,7 +48,7 @@ class TestDns(unittest.TestCase):
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + 'primary',
                                                     expected_payload, mock.ANY, axapi_args=None,
-                                                    max_retries=None, timeout=None)
+                                                    max_retries=None, timeout=mock.ANY)
 
     def test_secondary_ipv4(self):
         expected = '192.0.2.5'
@@ -58,7 +58,7 @@ class TestDns(unittest.TestCase):
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + 'secondary',
                                                     expected_payload, mock.ANY, axapi_args=None,
-                                                    max_retries=None, timeout=None)
+                                                    max_retries=None, timeout=mock.ANY)
 
     def test_secondary_ipv6(self):
         expected = '0:0:0:0:0:FFFF:129.144.52.39'
@@ -68,7 +68,7 @@ class TestDns(unittest.TestCase):
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + 'secondary',
                                                     expected_payload, mock.ANY, axapi_args=None,
-                                                    max_retries=None, timeout=None)
+                                                    max_retries=None, timeout=mock.ANY)
 
     def test_suffix(self):
         expected = 'example.com'
@@ -78,4 +78,4 @@ class TestDns(unittest.TestCase):
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + 'suffix',
                                                     expected_payload, mock.ANY, axapi_args=None,
-                                                    max_retries=None, timeout=None)
+                                                    max_retries=None, timeout=mock.ANY)

--- a/acos_client/tests/unit/v30/test_interface.py
+++ b/acos_client/tests/unit/v30/test_interface.py
@@ -33,12 +33,12 @@ class TestInterface(unittest.TestCase):
     def test_interface_get_list(self):
         self.target.get_list()
         self.client.http.request.assert_called_with("GET", self.url_prefix, {}, mock.ANY, axapi_args=None,
-                                                    max_retries=None, timeout=None)
+                                                    max_retries=None, timeout=mock.ANY)
 
     def test_interface_get(self):
         self.target.get()
         self.client.http.request.assert_called_with("GET", self.url_prefix, {}, mock.ANY, axapi_args=None,
-                                                    max_retries=None, timeout=None)
+                                                    max_retries=None, timeout=mock.ANY)
 
     def _test_interface_create_dhcp(self, dhcp=True):
         expected = 1 if dhcp else 0
@@ -47,7 +47,7 @@ class TestInterface(unittest.TestCase):
         self.target.create(ifnum, dhcp=dhcp)
         self.client.http.request.assert_called_with("POST", self.url_prefix,  # URL + ifnum expected
                                                     expected_payload, mock.ANY, axapi_args=None,
-                                                    max_retries=None, timeout=None)
+                                                    max_retries=None, timeout=mock.ANY)
 
     def test_interface_create_dhcp_negative(self):
         self._test_interface_create_dhcp(False)
@@ -61,14 +61,14 @@ class TestInterface(unittest.TestCase):
         ip_netmask = "255.255.255.0"
         self.target.create(ifnum, dhcp=False, ip_address=ip_address, ip_netmask=ip_netmask)
         self.client.http.request.assert_called_with("POST", self.url_prefix, mock.ANY, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_interface_delete(self):
         ifnum = 1
         self.target.delete(1)
         self.client.http.request.assert_called_with("DELETE", self.url_prefix + str(ifnum),
                                                     mock.ANY, mock.ANY, axapi_args=None, max_retries=None,
-                                                    timeout=None)
+                                                    timeout=mock.ANY)
 
     def test_interface_update(self):
         ifnum = 1
@@ -79,7 +79,7 @@ class TestInterface(unittest.TestCase):
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + str(ifnum),
                                                     mock.ANY, mock.ANY, axapi_args=None, max_retries=None,
-                                                    timeout=None)
+                                                    timeout=mock.ANY)
 
     def test_interface_enable_positive(self):
         ifnum = 1
@@ -94,7 +94,7 @@ class TestInterface(unittest.TestCase):
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + str(ifnum),
                                                     mock.ANY, mock.ANY, axapi_args=None, max_retries=None,
-                                                    timeout=None)
+                                                    timeout=mock.ANY)
 
     def test_interface_enable_negative(self):
         ifnum = 1
@@ -110,7 +110,7 @@ class TestInterface(unittest.TestCase):
 
         self.client.http.request.assert_called_with("POST", self.url_prefix + str(ifnum),
                                                     mock.ANY, mock.ANY, axapi_args=None, max_retries=None,
-                                                    timeout=None)
+                                                    timeout=mock.ANY)
 
 
 class TestEthernetInterface(TestInterface):

--- a/acos_client/tests/unit/v30/test_vlan.py
+++ b/acos_client/tests/unit/v30/test_vlan.py
@@ -35,13 +35,13 @@ class TestVlan(unittest.TestCase):
     def test_interface_get_list(self):
         self.target.get_list()
         self.client.http.request.assert_called_with("GET", self.url_prefix, {}, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_interface_get(self):
         self.target.get(self.vlan_id)
         self.client.http.request.assert_called_with(
             "GET", '{0}/{1}'.format(self.url_prefix, self.vlan_id), {}, mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None
+            axapi_args=None, max_retries=None, timeout=mock.ANY
         )
 
     def test_vlan_create_shared(self):
@@ -51,7 +51,7 @@ class TestVlan(unittest.TestCase):
         ep = self.expected_payload
         ep['vlan']['shared-vlan'] = True
         self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vlan_create_untagged_eths(self):
         untagged_eths = [{'untagged-ethernet-start': 2, 'untagged-ethernet-end': 2}]
@@ -62,7 +62,7 @@ class TestVlan(unittest.TestCase):
         ep = self.expected_payload
         ep['vlan']['untagged-eth-list'] = untagged_eths
         self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vlan_create_untagged_trunks(self):
         untagged_trunks = [{'untagged-trunk-start': 2, 'untagged-trunk-end': 2}]
@@ -74,7 +74,7 @@ class TestVlan(unittest.TestCase):
         ep = self.expected_payload
         ep['vlan']['untagged-trunk-list'] = untagged_trunks
         self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vlan_create_tagged_eths(self):
         tagged_eths = [{'tagged-ethernet-start': 2, 'tagged-ethernet-end': 2}]
@@ -85,7 +85,7 @@ class TestVlan(unittest.TestCase):
         ep = self.expected_payload
         ep['vlan']['tagged-eth-list'] = tagged_eths
         self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vlan_create_tagged_trunks(self):
         tagged_trunks = [{'tagged-trunk-start': 2, 'tagged-trunk-end': 2}]
@@ -96,7 +96,7 @@ class TestVlan(unittest.TestCase):
         ep = self.expected_payload
         ep['vlan']['tagged-trunk-list'] = tagged_trunks
         self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vlan_create_ve(self):
         self.target.create(self.vlan_id, shared_vlan=False, untagged_eths=[], untagged_trunks=[],
@@ -105,7 +105,7 @@ class TestVlan(unittest.TestCase):
         ep = self.expected_payload
         ep['vlan']['ve'] = 1
         self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vlan_create_lif(self):
         self.target.create(self.vlan_id, shared_vlan=False, untagged_eths=[], untagged_trunks=[],
@@ -114,11 +114,11 @@ class TestVlan(unittest.TestCase):
         ep = self.expected_payload
         ep['vlan']['untagged-lif'] = 6
         self.client.http.request.assert_called_with("POST", self.url_prefix, ep, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vlan_delete(self):
         self.target.delete(self.vlan_id)
         self.client.http.request.assert_called_with(
             "DELETE", '{0}/{1}'.format(self.url_prefix, self.vlan_id), mock.ANY, mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None
+            axapi_args=None, max_retries=None, timeout=mock.ANY
         )

--- a/acos_client/tests/unit/v30/test_vrrpa.py
+++ b/acos_client/tests/unit/v30/test_vrrpa.py
@@ -46,19 +46,19 @@ class TestVRID(unittest.TestCase):
     def test_vrid_get(self):
         self.target.get(0)
         self.client.http.request.assert_called_with("GET", self.url_prefix + '0', {}, mock.ANY,
-                                                    axapi_args=None, max_retries=None, timeout=None)
+                                                    axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vrid_create_threshold(self):
         self.target.create(4, threshold=2)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix, self.expected_payload(4, threshold=2), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vrid_create_disable(self):
         self.target.create(4, disable=1)
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix, self.expected_payload(4, disable=1), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vrid_create_floating_ip(self):
         self.target.create(4, threshold=1, disable=0, floating_ips=['10.10.10.8'])
@@ -66,19 +66,19 @@ class TestVRID(unittest.TestCase):
         payload['vrid']['floating-ip'] = mock.ANY
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix, payload, mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vrid_update_threshold(self):
         self.target.update(4, threshold=2)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix + '4', self.expected_payload(4, threshold=2), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vrid_update_disable(self):
         self.target.update(4, disable=1)
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix + '4', self.expected_payload(4, disable=1), mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_vrid_update_floating_ip(self):
         self.target.update(4, threshold=1, disable=0, floating_ips=['10.10.10.9'])
@@ -86,7 +86,7 @@ class TestVRID(unittest.TestCase):
         payload['vrid']['floating-ip'] = mock.ANY
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix + '4', payload,
-            mock.ANY, axapi_args=None, max_retries=None, timeout=None)
+            mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_patition_vrid_create_floating_ip(self):
         self.target.create(4, threshold=1, disable=0, floating_ips=['10.10.10.8'], is_partition=True)
@@ -94,7 +94,7 @@ class TestVRID(unittest.TestCase):
         payload['vrid']['floating-ip'] = mock.ANY
         self.client.http.request.assert_called_with(
             "POST", self.url_prefix, payload, mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_partition_vrid_update_floating_ip(self):
         self.target.update(4, threshold=1, disable=0, floating_ips=['10.10.10.9'], is_partition=True)
@@ -102,7 +102,7 @@ class TestVRID(unittest.TestCase):
         payload['vrid']['floating-ip'] = mock.ANY
         self.client.http.request.assert_called_with(
             "PUT", self.url_prefix + '4', payload, mock.ANY,
-            axapi_args=None, max_retries=None, timeout=None)
+            axapi_args=None, max_retries=None, timeout=mock.ANY)
 
     def test_build_params_multi_ip(self):
         floating_ips = ['11.11.11.11', '12.12.12.12', '13.13.13.13']

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -32,12 +32,14 @@ broken_replies = {
 
 
 class HttpClient(object):
+    AXAPI_DEFAULT_REQ_TIMEOUT = 300
     HEADERS = {
         "Content-type": "application/json",
         "User-Agent": "ACOS-Client-AGENT-%s" % acos_client.VERSION,
     }
 
-    def __init__(self, host, port=None, protocol="https", max_retries=3, timeout=5):
+    def __init__(self, host, port=None, protocol="https", max_retries=3,
+                 timeout=AXAPI_DEFAULT_REQ_TIMEOUT):
         if port is None:
             if protocol is 'http':
                 self.port = 80

--- a/acos_client/v30/base.py
+++ b/acos_client/v30/base.py
@@ -22,7 +22,6 @@ from acos_client import errors as ae
 
 
 class BaseV30(object):
-    AXAPI_DEFAULT_REQ_TIMEOUT = 300
 
     def __init__(self, client):
         self.client = client
@@ -65,23 +64,19 @@ class BaseV30(object):
                                      timeout=timeout, axapi_args=axapi_args, **kwargs)
             raise e
 
-    def _get(self, action, params={}, max_retries=None, timeout=AXAPI_DEFAULT_REQ_TIMEOUT,
-             axapi_args=None, **kwargs):
+    def _get(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
         return self._request('GET', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 
-    def _post(self, action, params={}, max_retries=None, timeout=AXAPI_DEFAULT_REQ_TIMEOUT,
-              axapi_args=None, **kwargs):
+    def _post(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
         return self._request('POST', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 
-    def _put(self, action, params={}, max_retries=None, timeout=AXAPI_DEFAULT_REQ_TIMEOUT,
-             axapi_args=None, **kwargs):
+    def _put(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
         return self._request('PUT', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 
-    def _delete(self, action, params={}, max_retries=None, timeout=AXAPI_DEFAULT_REQ_TIMEOUT,
-                axapi_args=None, **kwargs):
+    def _delete(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
         return self._request('DELETE', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 

--- a/acos_client/v30/base.py
+++ b/acos_client/v30/base.py
@@ -22,6 +22,7 @@ from acos_client import errors as ae
 
 
 class BaseV30(object):
+    AXAPI_DEFAULT_REQ_TIMEOUT = 300
 
     def __init__(self, client):
         self.client = client
@@ -64,19 +65,23 @@ class BaseV30(object):
                                      timeout=timeout, axapi_args=axapi_args, **kwargs)
             raise e
 
-    def _get(self, action, params={}, max_retries=None, timeout=300, axapi_args=None, **kwargs):
+    def _get(self, action, params={}, max_retries=None, timeout=AXAPI_DEFAULT_REQ_TIMEOUT,
+             axapi_args=None, **kwargs):
         return self._request('GET', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 
-    def _post(self, action, params={}, max_retries=None, timeout=300, axapi_args=None, **kwargs):
+    def _post(self, action, params={}, max_retries=None, timeout=AXAPI_DEFAULT_REQ_TIMEOUT,
+              axapi_args=None, **kwargs):
         return self._request('POST', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 
-    def _put(self, action, params={}, max_retries=None, timeout=300, axapi_args=None, **kwargs):
+    def _put(self, action, params={}, max_retries=None, timeout=AXAPI_DEFAULT_REQ_TIMEOUT,
+             axapi_args=None, **kwargs):
         return self._request('PUT', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 
-    def _delete(self, action, params={}, max_retries=None, timeout=300, axapi_args=None, **kwargs):
+    def _delete(self, action, params={}, max_retries=None, timeout=AXAPI_DEFAULT_REQ_TIMEOUT,
+                axapi_args=None, **kwargs):
         return self._request('DELETE', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 

--- a/acos_client/v30/base.py
+++ b/acos_client/v30/base.py
@@ -64,19 +64,19 @@ class BaseV30(object):
                                      timeout=timeout, axapi_args=axapi_args, **kwargs)
             raise e
 
-    def _get(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
+    def _get(self, action, params={}, max_retries=None, timeout=300, axapi_args=None, **kwargs):
         return self._request('GET', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 
-    def _post(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
+    def _post(self, action, params={}, max_retries=None, timeout=300, axapi_args=None, **kwargs):
         return self._request('POST', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 
-    def _put(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
+    def _put(self, action, params={}, max_retries=None, timeout=300, axapi_args=None, **kwargs):
         return self._request('PUT', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 
-    def _delete(self, action, params={}, max_retries=None, timeout=None, axapi_args=None, **kwargs):
+    def _delete(self, action, params={}, max_retries=None, timeout=300, axapi_args=None, **kwargs):
         return self._request('DELETE', action, params, max_retries=max_retries, timeout=timeout,
                              axapi_args=axapi_args, **kwargs)
 


### PR DESCRIPTION
## Description
**acos-client side PR: https://github.com/a10networks/acos-client/pull/340**
**a10-octavia side PR: https://github.com/a10networks/a10-octavia/pull/363**

If Bug Fix:
- Required: Severity Level Low
- Required: Issue Description:  Failed to create LB for public-subnet

According to the audi log:
```
vThunder(NOLICENSE)#show audi
Apr 13 2021 10:46:53  [admin] axapi: [7:192.168.0.127:34384] RESP HTTP status 400  Bad Request : Failed to acquire a DHCP offer from DHCP server.
Apr 13 2021 10:46:53  [admin] axapi: [7:192.168.0.127:34384] payload section 1
{"ethernet": {"action": "enable", "ip": {"dhcp": 1}, "ifnum": "1", "name": "DataPort"}}
Apr 13 2021 10:45:50  [admin] axapi: [7:192.168.0.127:34384] POST: /axapi/v3/interface/ethernet/1
```

- **Root Cause:**
1. The acos-client timeout is 30 seconds, but Thunder response this AXAPI request after 63 seconds.
2. the public-subnet didn’t enable dhcp service

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2220

## Technical Approach
1. set acos-client default timeout to 300, which is in another PR
2. public_subnet should enable dhcp
3. Fix some mirror issue in our revert flow

## Config Changes
<pre>
<b>N/A</b>
</pre>


## Test Cases
- Run following command
```shell
openstack loadbalancer create --vip-subnet-id public-subnet --name vip1
```


## Manual Testing
**After the patch, we can see the axapi response with the error message now (which is DHCP failed)**
```shell
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: WARNING a10_octavia.controller.worker.controller_worker [-] Flow 'octavia-create-loadbalancer-flow' (ff8cff27-6f22-4637-85ce-360e57621c8f) transitioned into state 'REVERTED' from state 'RUNNING'
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server [-] Exception during message handling: DhcpAcquireFailed: 654311505 Failed to acquire a DHCP offer from DHCP server.
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server Traceback (most recent call last):
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 166, in _process_incoming
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/opt/stack/source/a10-octavia/vThunder/a10_octavia/controller/queue/endpoint.py", line 45, in create_load_balancer
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     self.worker.create_load_balancer(load_balancer_id, flavor)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 292, in wrapped_f
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     return self.call(f, *args, **kw)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 358, in call
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     do = self.iter(retry_state=retry_state)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 319, in iter
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     return fut.result()
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 455, in result
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     return self.__get_result()
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/tenacity/__init__.py", line 361, in call
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     result = fn(*args, **kwargs)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/opt/stack/source/a10-octavia/vThunder/a10_octavia/controller/worker/controller_worker.py", line 312, in create_load_balancer
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     create_lb_tf.run()
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 247, in run
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     for _state in self.run_iter(timeout=timeout):
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/engine.py", line 340, in run_iter
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     failure.Failure.reraise_if_any(er_failures)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 339, in reraise_if_any
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     failures[0].reraise()
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/types/failure.py", line 346, in reraise
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     six.reraise(*self._exc_info)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/taskflow/engines/action_engine/executor.py", line 53, in _execute_task
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     result = task.execute(**arguments)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/opt/stack/source/a10-octavia/vThunder/a10_octavia/controller/worker/tasks/decorators.py", line 52, in wrapper
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     result = func(self, *args, **kwargs)
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server   File "/opt/stack/source/a10-octavia/vThunder/a10_octavia/controller/worker/tasks/vthunder_tasks.py", line 182, in execute
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server     raise e
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server DhcpAcquireFailed: 654311505 Failed to acquire a DHCP offer from DHCP server.
Apr 13 14:59:06 openstack-4 a10-octavia-worker[25972]: ERROR oslo_messaging.rpc.server

```

