### PR TITLE
[STACK-2302] Fix aFlex script import failed

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_aflex.py
+++ b/acos_client/tests/unit/v30/test_slb_aflex.py
@@ -56,8 +56,8 @@ class TestAFlex(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
-        self.assertIn(filename, responses.calls[1].request.body)
-        self.assertIn(action, responses.calls[1].request.body)
+        self.assertIn(filename, responses.calls[1].request.body.decode("utf-8"))
+        self.assertIn(action, responses.calls[1].request.body.decode("utf-8"))
 
     @mock.patch('acos_client.v30.slb.aflex_policy.AFlexPolicy.get')
     @responses.activate
@@ -76,8 +76,8 @@ class TestAFlex(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
-        self.assertIn(filename, responses.calls[1].request.body)
-        self.assertIn(action, responses.calls[1].request.body)
+        self.assertIn(filename, responses.calls[1].request.body.decode("utf-8"))
+        self.assertIn(action, responses.calls[1].request.body.decode("utf-8"))
 
     @mock.patch('acos_client.v30.slb.aflex_policy.AFlexPolicy.get')
     @responses.activate
@@ -93,5 +93,5 @@ class TestAFlex(unittest.TestCase):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[1].request.method, responses.POST)
         self.assertEqual(responses.calls[1].request.url, CREATE_URL)
-        self.assertIn(filename, responses.calls[1].request.body)
-        self.assertIn('delete', responses.calls[1].request.body)
+        self.assertIn(filename, responses.calls[1].request.body.decode("utf-8"))
+        self.assertIn('delete', responses.calls[1].request.body.decode("utf-8"))

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -172,6 +172,7 @@ class HttpClient(object):
         while attemps > 0:
             try:
                 return self.request_impl(method, api_url, params, headers,
+                                         file_name=file_name, file_content=file_content,
                                          max_retries=max_retries,
                                          timeout=timeout, axapi_args=axapi_args,
                                          **kwargs)


### PR DESCRIPTION
Fix degrade which caused by https://github.com/a10networks/acos-client/pull/341

The l7policy can't be create correctly since script content didn't import to ACOS.
This is caused by https://github.com/a10networks/acos-client/pull/341 which we  wrap the request() API but some parameter is missing while we wrap the API.