### PR TITLE
[STACK-2356] a10-octavia retry too long

### DIFF
--- a/acos_client/v30/responses.py
+++ b/acos_client/v30/responses.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 import re
 
 from acos_client import errors as ae
+from requests import exceptions as req_ex
 
 RESPONSE_CODES = {
     33619969: {
@@ -276,3 +277,7 @@ def raise_axapi_ex(response, method, api_url):
         raise ae.ACOSException(code, response['response']['err']['msg'])
 
     raise ae.ACOSException()
+
+
+def axapi_retry_exceptions():
+    return (ae.ACOSSystemIsBusy, ae.ACOSSystemNotReady, req_ex.ConnectionError)


### PR DESCRIPTION
## Description
If Bug Fix:
- Severity Level High
- Issue Description
1. acos-client may takes longer than 300 second for retry.
2. And after acos-client retry, a10-octavia still do another round of retry. And cause the retry takes very very long.

a10-octavia PR: https://github.com/a10networks/a10-octavia/pull/428

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2356

## Technical Approach
1. change acos-client retry mechanism to use time.time() to calculate actual retry time.
2. in a10-octavia, when acos-client already do the retry then adjust retries correctly.

## Config Changes
**This is only required if the config has been updated in this PR**
- Required: Provide example config snippet within pre block

<pre>
<b>
[a10_controller_worker]
amp_active_retries = 59
amp_active_wait_sec = 10
amp_vcs_retries = 59
amp_vcs_wait_sec = 10
</b>
</pre>


## Test Cases
1. delete instance when openstack running following tasks VThunderComputeConnectivityWait, ConfigureaVCSBackup, VCSSyncWait and GetMasterVThunder
2. measure the a10-octavia retry time. And the retry time should follow configuration option values.

## Manual Testing
1. rpdb on target tasks
2. delete instance when rpdb stop the process, and then continue it.
3. trace log to see how long it take for retry
