### PR TITLE
[STACK-2384][STACK-2396][STACK-2509]: VRID FIP is failed to be created or deleted on AX45 shared partition if the same subnet is used on AX35 shard or l3v partition in case of loadbalancer and member

### DIFF
--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -26,6 +26,9 @@ class Server(base.BaseV30):
         return self._get(self.url_prefix + name, max_retries=max_retries, timeout=timeout,
                          axapi_args=kwargs)
 
+    def get_all(self):
+        return self._get(self.url_prefix)
+
     def _set(self, name, ip_address, status=1, server_templates=None, port_list=None,
              conn_resume=None, conn_limit=None, health_check=None, **kwargs):
         params = {


### PR DESCRIPTION
## Description
Added an api `get_all()` for getting all servers present on a vthunder device.

## Related PR
https://github.com/a10networks/a10-octavia/pull/443