### PR TITLE
[STACK-2322]: Dynamic Interface Detection Enhancement

### DIFF
--- a/acos_client/tests/unit/test_utils.py
+++ b/acos_client/tests/unit/test_utils.py
@@ -1,0 +1,83 @@
+# Copyright 2014,  Doug Wiegley,  A10 Networks.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import acos_client
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_version(self):
+        exp = (4, 1, 1, 0, 0, 0)
+        tup = acos_client.utils.acos_version("4.1.1")
+        self.assertEqual(tup, exp)
+
+        exp = (4, 1, 1, 0, 2, 0)
+        tup = acos_client.utils.acos_version("4.1.1-P2")
+        self.assertEqual(tup, exp)
+
+        exp = (4, 1, 1, 0, 2, 0)
+        tup = acos_client.utils.acos_version("4.1.1-p2")
+        self.assertEqual(tup, exp)
+
+        exp = (4, 1, 4, 1, 2, 0)
+        tup = acos_client.utils.acos_version("4.1.4-GR1-P2")
+        self.assertEqual(tup, exp)
+
+        exp = (4, 1, 4, 1, 3, 4)
+        tup = acos_client.utils.acos_version("4.1.4-gr1-p3-sp4")
+        self.assertEqual(tup, exp)
+
+        exp = (4, 1, 4, 1, 3, 4)
+        tup = acos_client.utils.acos_version("4.1.4-GR1-P3-SP4")
+        self.assertEqual(tup, exp)
+
+        exp = (5, 2, 0, 0, 0, 0)
+        tup = acos_client.utils.acos_version("5.2.0")
+        self.assertEqual(tup, exp)
+
+    def test_version_cmp(self):
+        rt = acos_client.utils.acos_version_cmp("5.2.0", "4.2.0")
+        self.assertGreater(rt, 0)
+
+        rt = acos_client.utils.acos_version_cmp("5.3.0", "5.2.0")
+        self.assertGreater(rt, 0)
+
+        rt = acos_client.utils.acos_version_cmp("5.2.0", "5.2.0")
+        self.assertEqual(rt, 0)
+
+        rt = acos_client.utils.acos_version_cmp("5.2.1", "5.2.0")
+        self.assertGreater(rt, 0)
+
+        rt = acos_client.utils.acos_version_cmp("5.2.1-P1", "5.2.1")
+        self.assertGreater(rt, 0)
+
+        rt = acos_client.utils.acos_version_cmp("5.2.1-GR1-P1", "5.2.1-GR1")
+        self.assertGreater(rt, 0)
+
+        rt = acos_client.utils.acos_version_cmp("5.2.1-GR1-P3-SP1", "5.2.1-GR1-P3")
+        self.assertGreater(rt, 0)
+
+        # case insensitive
+        rt = acos_client.utils.acos_version_cmp("5.2.1-GR1-p1", "5.2.1-GR1")
+        self.assertGreater(rt, 0)
+
+        rt = acos_client.utils.acos_version_cmp("5.2.1-GR1-P3-SP1", "5.2.1-gr1-p3-sp1")
+        self.assertEqual(rt, 0)

--- a/acos_client/utils.py
+++ b/acos_client/utils.py
@@ -1,0 +1,65 @@
+# Copyright 2021,  Jeff Buttars,  A10 Networks.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+
+def acos_version_str2int(ver):
+    if ver.isdigit():
+        return int(ver)
+    else:
+        vnum = ""
+        for index in range(len(ver)):
+            if ver[index].isdigit():
+                vnum = vnum + ver[index]
+            else:
+                break
+        return int(vnum)
+
+
+def acos_revision_parse(revision):
+    rev = []
+    revision_list = ['GR', 'P', 'SP']
+    for tag in revision_list:
+        tag_index = revision.find(tag)
+        if tag_index >= 0:
+            tag_len = len(tag)
+            rev.append(acos_version_str2int(revision[(tag_index + tag_len):]))
+        else:
+            rev.append(0)
+
+    return tuple(rev)
+
+
+def acos_version(acos_version):
+    major = acos_version_str2int(acos_version.split('.')[0])
+    minor = acos_version_str2int(acos_version.split('.')[1])
+    patch = acos_version_str2int(acos_version.split('.')[2])
+
+    revision = ""
+    prev = acos_version.find('-')
+    if prev > 0:
+        revision = acos_version[prev + 1:].upper()
+    gr, p, sp = acos_revision_parse(revision)
+
+    return (major, minor, patch, gr, p, sp)
+
+
+def acos_version_cmp(ver1, ver2):
+    vtup1 = acos_version(ver1)
+    vtup2 = acos_version(ver2)
+    for index in range(len(vtup1)):
+        if vtup1[index] != vtup2[index]:
+            return vtup1[index] - vtup2[index]
+    return 0

--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -17,6 +17,8 @@ from __future__ import unicode_literals
 from acos_client import errors as ae
 from acos_client.v30 import base
 
+import acos_client.utils as utils
+
 
 class Action(base.BaseV30):
 
@@ -53,6 +55,10 @@ class Action(base.BaseV30):
 
     def reload(self):
         self._post("/reload", "")
+
+    def reload_all(self):
+        payload = {"reload": {"all": 1}}
+        self._post("/reload", payload)
 
     def setInterface(self, interface):
         data = {"ethernet": {"ifnum": str(interface), "name": "DataPort",
@@ -133,13 +139,9 @@ class Action(base.BaseV30):
             version_summary = self.get_acos_version()
             acos_version = version_summary['version']['oper']['sw-version'].split(',')[0]
 
-        major = acos_version.split('.')[0]
-        minor = acos_version.split('.')[1]
-        patch = acos_version.split('.')[2]
-
-        if major >= 5 and minor >= 2 and patch >= 0:
+        if utils.acos_version_cmp(acos_version, "5.2.0") >= 0:
             self.probe_network_devices()
-            self.reload()
+            self.reload_all()
         else:
             self.reboot()
 
@@ -148,12 +150,8 @@ class Action(base.BaseV30):
             version_summary = self.get_acos_version()
             acos_version = version_summary['version']['oper']['sw-version'].split(',')[0]
 
-        major = acos_version.split('.')[0]
-        minor = acos_version.split('.')[1]
-        patch = acos_version.split('.')[2]
-
-        if major >= 5 and minor >= 2 and patch >= 1:
+        if utils.acos_version_cmp(acos_version, "5.2.1") >= 0:
             self.probe_network_devices()
-            self.reload()
+            self.reload_all()
         else:
             self.reboot()


### PR DESCRIPTION
## Description
Added a new API reload_all() for supporting dynamic interface detection enhancement.

## Related PR of a10-octavia side:
https://github.com/a10networks/a10-octavia/pull/480

## Jira tickets
https://a10networks.atlassian.net/browse/STACK-2473
https://a10networks.atlassian.net/browse/STACK-2474

## Technical Approach
- Added a new API reload_all() for reloading all devices in a cluster at a time.
- Modified reload_reboot_for_interface_attachment() and reload_reboot_for_interface_detachment() to use new API (to replace self.reload()) to reload_all VCS cluster devices.
