### PR TITLE
[STACK-2610] Add support for capacity flexpool

### DIFF
--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -41,6 +41,7 @@ from acos_client.v30.file import File as v30_File
 from acos_client.v30.ha import HA as v30_HA
 from acos_client.v30.interface import Interface as v30_Interface
 from acos_client.v30.license_manager import LicenseManager as v30_LicenseManager
+from acos_client.v30.glm.flexpool import Flexpool as Flexpool
 from acos_client.v30.nat import Nat as v30_Nat
 from acos_client.v30.network import Network as v30_Network
 from acos_client.v30.overlay import Overlay as v30_Overlay
@@ -85,7 +86,8 @@ VERSION_IMPORTS = {
         'File': v30_File,
         'Vlan': v30_Vlan,
         'VRRPA': v30_VRRPA,
-        'DeviceContext': v30_DeviceContext
+        'DeviceContext': v30_DeviceContext,
+        'Flexpool': Flexpool
     },
 }
 
@@ -168,7 +170,7 @@ class Client(object):
         if self._version != '30':
             LOG.error("AXAPIv21 is not supported for the glm attribute")
             return
-        return VERSION_IMPORTS['30']["GlobalLicenseManager"](self)
+        return VERSION_IMPORTS['30']["Flexpool"](self)
 
     @property
     def overlay(self):

--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -159,7 +159,16 @@ class Client(object):
 
     @property
     def license_manager(self):
+        LOG.warning("The paygo method been deprecated and will be removed "
+                    "in a future release.")
         return VERSION_IMPORTS[self._version]["LicenseManager"](self)
+
+    @property
+    def glm(self):
+        if self._version != '30':
+            LOG.error("AXAPIv21 is not supported for the glm attribute")
+            return
+        return VERSION_IMPORTS['30']["GlobalLicenseManager"](self)
 
     @property
     def overlay(self):

--- a/acos_client/errors.py
+++ b/acos_client/errors.py
@@ -13,6 +13,16 @@
 #    under the License.
 
 
+class RequiredAttributeNotSpecified(Exception):
+
+    def __init__(self, url, attribute, requires=[]):
+        required_str = str(requires).strip("[]")
+        self.message = ("The attribute {attribute} requires that {requires}"
+                        "also be specified when querying "
+                        "the {url} endpoint.").format(url, attribute, required_str)
+        super(RequiredAttributeNotSpecified, self).__init__(self.message)
+
+
 class ACOSException(Exception):
     def __init__(self, code=1, msg=''):
         self.code = code

--- a/acos_client/v30/dns.py
+++ b/acos_client/v30/dns.py
@@ -47,3 +47,13 @@ class DNS(base.BaseV30):
 
         if suffix is not None:
             self._set_suffix(suffix)
+
+    def delete(self, primary=None, secondary=None, suffix=None):
+        if primary is not None:
+            self._delete(self.url_prefix + 'primary')
+
+        if secondary is not None:
+            self._delete(self.url_prefix + 'secondary')
+
+        if summary is not None:
+            self._delete(self.url_prefix + 'suffix')

--- a/acos_client/v30/dns.py
+++ b/acos_client/v30/dns.py
@@ -55,5 +55,5 @@ class DNS(base.BaseV30):
         if secondary is not None:
             self._delete(self.url_prefix + 'secondary')
 
-        if summary is not None:
+        if suffix is not None:
             self._delete(self.url_prefix + 'suffix')

--- a/acos_client/v30/glm/flexpool.py
+++ b/acos_client/v30/glm/flexpool.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2021, A10 Networks Inc. All rights reserved.
+
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from acos_client.v30 import base
+from acos_client.v30.glm.proxy import ProxyServer
+from acos_client.v30.glm.license import LicenseRequest
+
+
+class Flexpool(base.BaseV30):
+    url_prefix = '/glm'
+
+    @property
+    def proxy_server(self):
+        return ProxyServer(self.client)
+
+    @property
+    def create_license_request(self):
+        return LicenseRequest(self.client)
+
+    @property
+    def new_licese(self):
+        return NewLicense(self.client)
+
+    @property
+    def send(self):
+        return Send(self.client)
+
+    def _set(self, appliance_name=None, allocate_bandwith=None, burst=None,
+             check_expiration=None, enable_requests=None, enterpise=None,
+             enterprise_request_type=None, host=None, interval=None,
+             port=None, thunder_capacity_license=None, token=None,
+             use_mgmt_port=None, uuid=None, **kwargs):
+        
+        params = {
+            "glm": self.minimal_dict({
+                "uuid": uuid,
+                "host": host,
+                "port": port,
+                "burst": burst,
+                "token": token,
+                "interval": interval,
+                "enterpise": enterpise,
+                "use-mgmt-port": use_mgmt_port,
+                "appliance-name": appliance_name,
+                "enable-requests": enable_requests,
+                "check-expiration": check_expiration,
+                "allocate-bandwidth": allocate_bandwith,
+                "enterprise-request-type": enterprise_request_type,
+                "thunder-capacity-license": thunder_capacity_license,
+            })
+        }
+
+        return params, kwargs
+
+    def create(self, *args, **kwargs):
+        params, kwargs = self._set(*args, **kwargs)
+        return self._post(self.url_prefix, params, axapi_args=kwargs)
+
+    def update(self, *args, **kwargs):
+        params, kwargs = self._set(*args, **kwargs)
+        return self._post(self.url_prefix, params, axapi_args=kwargs)
+
+    def replace(self, *args, **kwargs):
+        params, kwargs = self._set(*args, **kwargs)
+        return self._put(self.url_prefix, params, axapi_args=kwargs)
+
+    def delete(self):
+        return self._delete(self.url_prefix)
+
+
+class Send(base.BaseV30):
+    url_prefix = '/glm/send'
+
+    def create(self, license_request=None):
+        params = {
+            "send": self.minimal_dict({
+                "license-request": license_request
+            })
+        }
+
+        self._post(self.url_prefix, params)
+
+
+class NewLicense(base.BaseV30):
+    url_prefix = '/glm/send'
+
+    def create(self, license_request=None):
+        params = {
+            "send": self.minimal_dict({
+                "license-request": license_request
+            })
+        }
+
+        self._post(self.url_prefix, params)

--- a/acos_client/v30/glm/flexpool.py
+++ b/acos_client/v30/glm/flexpool.py
@@ -13,8 +13,8 @@
 #    under the License.
 
 from acos_client.v30 import base
-from acos_client.v30.glm.proxy import ProxyServer
-from acos_client.v30.glm.license import LicenseRequest
+from acos_client.v30.glm import proxy
+from acos_client.v30.glm import license
 
 
 class Flexpool(base.BaseV30):
@@ -22,15 +22,15 @@ class Flexpool(base.BaseV30):
 
     @property
     def proxy_server(self):
-        return ProxyServer(self.client)
+        return proxy.ProxyServer(self.client)
 
     @property
     def create_license_request(self):
-        return LicenseRequest(self.client)
+        return license.LicenseRequest(self.client)
 
     @property
     def new_licese(self):
-        return NewLicense(self.client)
+        return license.NewLicense(self.client)
 
     @property
     def send(self):
@@ -40,11 +40,10 @@ class Flexpool(base.BaseV30):
              check_expiration=None, enable_requests=None, enterpise=None,
              enterprise_request_type=None, host=None, interval=None,
              port=None, thunder_capacity_license=None, token=None,
-             use_mgmt_port=None, uuid=None, **kwargs):
+             use_mgmt_port=None):
         
         params = {
             "glm": self.minimal_dict({
-                "uuid": uuid,
                 "host": host,
                 "port": port,
                 "burst": burst,
@@ -61,18 +60,48 @@ class Flexpool(base.BaseV30):
             })
         }
 
-        return params, kwargs
+        return params
 
-    def create(self, *args, **kwargs):
-        params, kwargs = self._set(*args, **kwargs)
+    def create(self, appliance_name=None, allocate_bandwith=None, burst=None,
+               check_expiration=None, enable_requests=None, enterpise=None,
+               enterprise_request_type=None, host=None, interval=None,
+               port=None, thunder_capacity_license=None, token=None,
+               use_mgmt_port=None, **kwargs):
+        params = self._set(appliance_name=appliance_name,
+            allocate_bandwith=allocate_bandwith, burst=burst,
+            check_expiration=check_expiration, enable_requests=enable_requests,
+            enterpise=enterpise, enterprise_request_type=enterprise_request_type,
+            thunder_capacity_license=thunder_capacity_license,
+            token=token, use_mgmt_port=use_mgmt_port,
+            host=host, interval=interval, port=port)
         return self._post(self.url_prefix, params, axapi_args=kwargs)
 
-    def update(self, *args, **kwargs):
-        params, kwargs = self._set(*args, **kwargs)
+    def update(self, appliance_name=None, allocate_bandwith=None, burst=None,
+             check_expiration=None, enable_requests=None, enterpise=None,
+             enterprise_request_type=None, host=None, interval=None,
+             port=None, thunder_capacity_license=None, token=None,
+             use_mgmt_port=None, **kwargs):
+        params, kwargs = self._set(appliance_name=appliance_name,
+            allocate_bandwith=allocate_bandwith, burst=burst,
+            check_expiration=check_expiration, enable_requests=enable_requests,
+            enterpise=enterpise, enterprise_request_type=enterprise_request_type,
+            thunder_capacity_license=thunder_capacity_license,
+            token=token, use_mgmt_port=use_mgmt_port,
+            host=host, interval=interval, port=port)
         return self._post(self.url_prefix, params, axapi_args=kwargs)
 
-    def replace(self, *args, **kwargs):
-        params, kwargs = self._set(*args, **kwargs)
+    def replace(self, appliance_name=None, allocate_bandwith=None, burst=None,
+             check_expiration=None, enable_requests=None, enterpise=None,
+             enterprise_request_type=None, host=None, interval=None,
+             port=None, thunder_capacity_license=None, token=None,
+             use_mgmt_port=None, **kwargs):
+        params, kwargs = self._set(appliance_name=appliance_name,
+            allocate_bandwith=allocate_bandwith, burst=burst,
+            check_expiration=check_expiration, enable_requests=enable_requests,
+            enterpise=enterpise, enterprise_request_type=enterprise_request_type,
+            thunder_capacity_license=thunder_capacity_license,
+            token=token, use_mgmt_port=use_mgmt_port,
+            host=host, interval=interval, port=port)
         return self._put(self.url_prefix, params, axapi_args=kwargs)
 
     def delete(self):
@@ -82,20 +111,7 @@ class Flexpool(base.BaseV30):
 class Send(base.BaseV30):
     url_prefix = '/glm/send'
 
-    def create(self, license_request=None):
-        params = {
-            "send": self.minimal_dict({
-                "license-request": license_request
-            })
-        }
-
-        self._post(self.url_prefix, params)
-
-
-class NewLicense(base.BaseV30):
-    url_prefix = '/glm/send'
-
-    def create(self, license_request=None):
+    def create(self, license_request):
         params = {
             "send": self.minimal_dict({
                 "license-request": license_request

--- a/acos_client/v30/glm/license.py
+++ b/acos_client/v30/glm/license.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2021, A10 Networks Inc. All rights reserved.
+
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from acos_client.v30 import base
+
+
+class LicenseRequest(base.BaseV30):
+    url_prefix = '/glm/create-license-request'
+
+    def _set(self, create_license_request):
+        params = {
+            'create-license-request': create_license_request
+        }
+
+        return params
+
+    def create(self, create_license_request=None,  **kwargs):
+        params = self._set(create_license_request=None)
+        return self._post(self.url_prefix, params, axapi_args=kwargs)
+
+    def update(self, create_license_request=None, **kwargs):
+        params = self._set(create_license_request=None)
+        return self._post(self.url_prefix, params, axapi_args=kwargs)
+
+    def put(self, create_license_request=None, **kwargs):
+        params = self._set(create_license_request=None)
+        return self._put(self.url_prefix, params, axapi_args=kwargs)
+
+    def delete(self):
+        return self._delete(self.url_prefix)
+
+
+class NewLicense(base.BaseV30):
+    url_prefix = '/glm/send'
+
+    def create(self, license_request=None):
+        params = {
+            "send": self.minimal_dict({
+                "license-request": license_request
+            })
+        }
+
+        self._post(self.url_prefix, params)

--- a/acos_client/v30/glm/proxy.py
+++ b/acos_client/v30/glm/proxy.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2021, A10 Networks Inc. All rights reserved.
+
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from acos_client.v30 import base
+
+
+class SecretStringUndefinedException(Exception):
+
+    def __init__(self):
+        self.message = ("The secret_string argument must "
+                        "be defined if password is specified.")
+        super(SecretStringUndefinedException, self).__init__(self.message)
+        
+
+class ProxyServer(base.BaseV30):
+    url_prefix = '/glm/proxy-server'
+
+    def _set(self, host=None, port=None, username=None,
+             password=None, secret_string=None):
+        params = {
+            'host': host,
+            'port': port,
+            'username': username,
+            'password': password,
+            'secret_string': secret_string
+        }
+
+        if password and not secret_string:
+            raise SecretStringUndefinedException()
+
+        return params
+
+    def create(self, host=None, port=None, username=None,
+               password=None, secret_string=None, **kwargs):
+        params = self._set(host=host, port=port, username=username,
+                           password=password, secret_string=secret_string)
+        return self._post(self.url_prefix, params, axapi_args=kwargs)
+
+    def update(self, host=None, port=None, username=None,
+               password=None, secret_string=None, **kwargs):
+        params = self._set(host=host, port=port, username=username,
+                           password=password, secret_string=secret_string)
+        return self._post(self.url_prefix, params, axapi_args=kwargs)
+
+    def put(self, host=None, port=None, username=None,
+            password=None, secret_string=None, **kwargs):
+        params = self._set(host=host, port=port, username=username,
+                           password=password, secret_string=secret_string)
+        return self._put(self.url_prefix, params, axapi_args=kwargs)
+
+    def delete(self):
+        return self._delete(self.url_prefix)

--- a/acos_client/v30/license_manager.py
+++ b/acos_client/v30/license_manager.py
@@ -28,6 +28,10 @@ DEFAULT_LICENSE_PORT = 443
 
 
 class LicenseManager(base.BaseV30):
+    """
+    This class and endpoint are designed to be used exclusively with the
+    'Pay-as-you-Go' licensing model.
+    """
 
     url_base = "/license-manager"
 


### PR DESCRIPTION
# Description 
While the acos-client previously had support for the "pay-go" licensing model, this PR adds endpoints required to support the "Capacity Flexpool" model.

For further details please see https://github.com/a10networks/a10-octavia/pull/487