### PR TITLE
[STACK-2769] Secondary DNS is deleted before primary

### DIFF
--- a/acos_client/v30/dns.py
+++ b/acos_client/v30/dns.py
@@ -49,11 +49,11 @@ class DNS(base.BaseV30):
             self._set_suffix(suffix)
 
     def delete(self, primary=None, secondary=None, suffix=None):
-        if primary is not None:
-            self._delete(self.url_prefix + 'primary')
+        if suffix is not None:
+            self._delete(self.url_prefix + 'suffix')
 
         if secondary is not None:
             self._delete(self.url_prefix + 'secondary')
 
-        if suffix is not None:
-            self._delete(self.url_prefix + 'suffix')
+        if primary is not None:
+            self._delete(self.url_prefix + 'primary')

--- a/acos_client/v30/glm/flexpool.py
+++ b/acos_client/v30/glm/flexpool.py
@@ -36,7 +36,7 @@ class Flexpool(base.BaseV30):
     def send(self):
         return Send(self.client)
 
-    def _set(self, appliance_name=None, allocate_bandwith=None, burst=None,
+    def _set(self, appliance_name=None, allocate_bandwidth=None, burst=None,
              check_expiration=None, enable_requests=None, enterpise=None,
              enterprise_request_type=None, host=None, interval=None,
              port=None, thunder_capacity_license=None, token=None,
@@ -54,21 +54,20 @@ class Flexpool(base.BaseV30):
                 "appliance-name": appliance_name,
                 "enable-requests": enable_requests,
                 "check-expiration": check_expiration,
-                "allocate-bandwidth": allocate_bandwith,
+                "allocate-bandwidth": allocate_bandwidth,
                 "enterprise-request-type": enterprise_request_type,
                 "thunder-capacity-license": thunder_capacity_license,
             })
         }
-
         return params
 
-    def create(self, appliance_name=None, allocate_bandwith=None, burst=None,
+    def create(self, appliance_name=None, allocate_bandwidth=None, burst=None,
                check_expiration=None, enable_requests=None, enterpise=None,
                enterprise_request_type=None, host=None, interval=None,
                port=None, thunder_capacity_license=None, token=None,
                use_mgmt_port=None, **kwargs):
         params = self._set(appliance_name=appliance_name,
-                           allocate_bandwith=allocate_bandwith, burst=burst,
+                           allocate_bandwidth=allocate_bandwidth, burst=burst,
                            check_expiration=check_expiration, enable_requests=enable_requests,
                            enterpise=enterpise, enterprise_request_type=enterprise_request_type,
                            thunder_capacity_license=thunder_capacity_license,
@@ -76,13 +75,13 @@ class Flexpool(base.BaseV30):
                            host=host, interval=interval, port=port)
         return self._post(self.url_prefix, params, axapi_args=kwargs)
 
-    def update(self, appliance_name=None, allocate_bandwith=None, burst=None,
+    def update(self, appliance_name=None, allocate_bandwidth=None, burst=None,
                check_expiration=None, enable_requests=None, enterpise=None,
                enterprise_request_type=None, host=None, interval=None,
                port=None, thunder_capacity_license=None, token=None,
                use_mgmt_port=None, **kwargs):
         params, kwargs = self._set(appliance_name=appliance_name,
-                                   allocate_bandwith=allocate_bandwith, burst=burst,
+                                   allocate_bandwidth=allocate_bandwidth, burst=burst,
                                    check_expiration=check_expiration, enable_requests=enable_requests,
                                    enterpise=enterpise, enterprise_request_type=enterprise_request_type,
                                    thunder_capacity_license=thunder_capacity_license,
@@ -90,13 +89,13 @@ class Flexpool(base.BaseV30):
                                    host=host, interval=interval, port=port)
         return self._post(self.url_prefix, params, axapi_args=kwargs)
 
-    def replace(self, appliance_name=None, allocate_bandwith=None, burst=None,
+    def replace(self, appliance_name=None, allocate_bandwidth=None, burst=None,
                 check_expiration=None, enable_requests=None, enterpise=None,
                 enterprise_request_type=None, host=None, interval=None,
                 port=None, thunder_capacity_license=None, token=None,
                 use_mgmt_port=None, **kwargs):
         params, kwargs = self._set(appliance_name=appliance_name,
-                                   allocate_bandwith=allocate_bandwith, burst=burst,
+                                   allocate_bandwidth=allocate_bandwidth, burst=burst,
                                    check_expiration=check_expiration, enable_requests=enable_requests,
                                    enterpise=enterpise,
                                    enterprise_request_type=enterprise_request_type,


### PR DESCRIPTION
Severity: High

Description: The secondary dns delete call was being performed before the primary. Fixed by swapping order of calls.