### PR TITLE
[STACK-2922] Setting burst to enabled on a non-burst license cause system freeze

### DIFF
--- a/acos_client/errors.py
+++ b/acos_client/errors.py
@@ -131,3 +131,7 @@ class ACOSSystemNotReady(ACOSException):
 
 class ACOSSystemIsBusy(ACOSException):
     pass
+
+
+class LicenseOptionNotAllowed(ACOSException):
+    pass

--- a/acos_client/v30/responses.py
+++ b/acos_client/v30/responses.py
@@ -223,6 +223,7 @@ RESPONSE_CODES = {
     },
     4294967295: {
         '*': {
+            '/axapi/v3/glm': ae.LicenseOptionNotAllowed,
             '*': ae.ConfigManagerNotReady
         }
     },
@@ -243,6 +244,7 @@ def raise_axapi_auth_error(response, method, api_url, headers):
 
 
 def raise_axapi_ex(response, method, api_url):
+
     if 'response' in response and 'err' in response['response']:
         code = response['response']['err']['code']
 


### PR DESCRIPTION
### Severity: Critical

## Description:
The ConfigManagerNotReady exception shares it's error code with exceptions caused by license requests with unpurchased license options. This results in the retry logic for the config manager to be called thus locking the execution for 2 minutes (5 second wait 24 times).

A new error has been added and is called whenever an exception with error code 4294967295 is raised during a request to the glm endpoint.