### PR TITLE
[BUG][STACK-2996]: [Flexpool Integration]Proxy Server configurations not getting pushed on vthunder devices. 

### DIFF
--- a/acos_client/v30/glm/proxy.py
+++ b/acos_client/v30/glm/proxy.py
@@ -29,11 +29,13 @@ class ProxyServer(base.BaseV30):
     def _set(self, host=None, port=None, username=None,
              password=None, secret_string=None):
         params = {
-            'host': host,
-            'port': port,
-            'username': username,
-            'password': password,
-            'secret_string': secret_string
+            'proxy-server': {
+                'host': host,
+                'port': port,
+                'username': username,
+                'password': password,
+                'secret-string': secret_string
+            }
         }
 
         if password and not secret_string:


### PR DESCRIPTION
# Description
 **Severity**: High
 **Description**: vthunder devices are not getting configured with GLM proxy-server configurations. 
The request payload for create API  '/axapi/v3/glm/proxy-server' is not correct.
**Provided**
```
{
    "username": "string",
    "uuid": "string",
    "encrypted": "Unknown Type: encrypted",
    "host": "string",
    "password": 0,
    "port": 0,
    "secret-string": "string"
  }
```

**Expected:**
```
{
  "proxy-server": {
    "username": "string",
    "uuid": "string",
    "encrypted": "Unknown Type: encrypted",
    "host": "string",
    "password": 0,
    "port": 0,
    "secret-string": "string"
  }
}
```
