### PR TITLE
[STACK-3126] Burst is not enabled when set in the a10-octavia config

### DIFF
--- a/acos_client/v30/glm/flexpool.py
+++ b/acos_client/v30/glm/flexpool.py
@@ -80,13 +80,13 @@ class Flexpool(base.BaseV30):
                enterprise_request_type=None, host=None, interval=None,
                port=None, thunder_capacity_license=None, token=None,
                use_mgmt_port=None, **kwargs):
-        params, kwargs = self._set(appliance_name=appliance_name,
-                                   allocate_bandwidth=allocate_bandwidth, burst=burst,
-                                   check_expiration=check_expiration, enable_requests=enable_requests,
-                                   enterpise=enterpise, enterprise_request_type=enterprise_request_type,
-                                   thunder_capacity_license=thunder_capacity_license,
-                                   token=token, use_mgmt_port=use_mgmt_port,
-                                   host=host, interval=interval, port=port)
+        params = self._set(appliance_name=appliance_name,
+                           allocate_bandwidth=allocate_bandwidth, burst=burst,
+                           check_expiration=check_expiration, enable_requests=enable_requests,
+                           enterpise=enterpise, enterprise_request_type=enterprise_request_type,
+                           thunder_capacity_license=thunder_capacity_license,
+                           token=token, use_mgmt_port=use_mgmt_port,
+                           host=host, interval=interval, port=port)
         return self._post(self.url_prefix, params, axapi_args=kwargs)
 
     def replace(self, appliance_name=None, allocate_bandwidth=None, burst=None,
@@ -94,14 +94,14 @@ class Flexpool(base.BaseV30):
                 enterprise_request_type=None, host=None, interval=None,
                 port=None, thunder_capacity_license=None, token=None,
                 use_mgmt_port=None, **kwargs):
-        params, kwargs = self._set(appliance_name=appliance_name,
-                                   allocate_bandwidth=allocate_bandwidth, burst=burst,
-                                   check_expiration=check_expiration, enable_requests=enable_requests,
-                                   enterpise=enterpise,
-                                   enterprise_request_type=enterprise_request_type,
-                                   thunder_capacity_license=thunder_capacity_license,
-                                   token=token, use_mgmt_port=use_mgmt_port,
-                                   host=host, interval=interval, port=port)
+        params = self._set(appliance_name=appliance_name,
+                           allocate_bandwidth=allocate_bandwidth, burst=burst,
+                           check_expiration=check_expiration, enable_requests=enable_requests,
+                           enterpise=enterpise,
+                           enterprise_request_type=enterprise_request_type,
+                           thunder_capacity_license=thunder_capacity_license,
+                           token=token, use_mgmt_port=use_mgmt_port,
+                           host=host, interval=interval, port=port)
         return self._put(self.url_prefix, params, axapi_args=kwargs)
 
     def delete(self):


### PR DESCRIPTION
# Description
Previously the acos-client glm flexpool `_set` method had returned two values. However, that was alerted in patch and the change was not propagated to the replace/update methods. This resulted in issues with enabling bursting via the update method

Please see https://github.com/a10networks/a10-octavia/pull/554 for futher details