### PR TITLE
[STACK-3171] Handle HealthMonitor PING case

### DIFF
--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -87,7 +87,7 @@ class HealthMonitor(base.BaseV30):
         if expect_code:
             k = "%s-response-code" % mon_method
             params['monitor']['method'][mon_method][k] = str(expect_code)
-        if port:
+        if mon_method != self.ICMP and port:
             if mon_method == self.HTTPS:
                 k = 'web-port'
             else:


### PR DESCRIPTION
[Description]
Health Monitor with PING type creation will failed with the patch of STACK-3171
We need to take care ICMP/PING type health monitor case in acos-client. since it don't have port or overwrite port.

---

[LOG]

**- openstack**

```
stack@ytsai-victoria:~/source/a10-octavia/Fully_Polulated_LB$ openstack loadbalancer healthmonitor create --delay 30 --timeout 3 --max-retries 3 --type PING --name hm1 pool1
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| project_id          | ecc2542be2644881b049636b719ca536     |
| name                | hm1                                  |
| admin_state_up      | True                                 |
| pools               | cdcfd2d8-4821-4575-ba6c-688f9f09cf8c |
| created_at          | 2022-06-24T03:52:47                  |
| provisioning_status | PENDING_CREATE                       |
| updated_at          | None                                 |
| delay               | 30                                   |
| expected_codes      | None                                 |
| max_retries         | 3                                    |
| http_method         | None                                 |
| timeout             | 3                                    |
| max_retries_down    | 3                                    |
| url_path            | None                                 |
| type                | PING                                 |
| id                  | 3006a2d9-b314-416f-9396-5dd82c65843d |
| operating_status    | OFFLINE                              |
| http_version        | None                                 |
| domain_name         | None                                 |
+---------------------+--------------------------------------+

**- thunder**

```
health monitor 3006a2d9-b314-416f-9396-5dd82c65843d
  interval 30 timeout 3

```

```