### PR TITLE
[STACK-3250] Fully Populated Loadbalancer Create

### DIFF
--- a/acos_client/v30/slb/aflex_policy.py
+++ b/acos_client/v30/slb/aflex_policy.py
@@ -38,7 +38,6 @@ class AFlexPolicy(base.BaseV30):
 
         obj_params = {
             "file": file,
-            "size": size,
             "file-handle": file,
             "action": action,
         }


### PR DESCRIPTION
## Description
    Per the Octavia API documentation, it supports the ability to create a fully populated loadbalancer, a single request with the VIP, listener, pool, members, and health checks all in one single request sent to the Octavia api.

    The current Openstack Cloud Controller Manager code (used for Kubernetes support) as of 1.21 uses fully populated load balancers for initial service creations by default. However, 1.20 did not support using providers other than “Octavia” or “amphora” so that code doesn’t work for us, our users are currently on 1.19.

     Our users can’t use the latest code or send POST requests with fully populated load balancers despite the Octavia documentation telling them its supported, if they do there isn’t any sort of error or response to the user/API.  Instead, the load balancer and all its child objects are stuck in an immutable PENDING_ state that requires manual intervention on the hardware a10, database cleanup by hand and then Openstack port deletion to clean up.


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3250

## Technical Approach
The detail design and descriptions are in design document: 
https://a10networks.sharepoint.com/:w:/s/Openstack/EemG6Tl7hfNGh8handWyMZwBhKjYc0ra25xqaHuqQhTMzg?e=crP4Al


## Config Changes

<pre>
<b>N/A</b>
</pre>

## Test Cases
Please reference unit-test document for detail testing steps, configuration, commands and logs:
https://a10networks.sharepoint.com/:w:/s/Openstack/ETC9KkK0VThBsY9E-mclFwgBo7FJPPGq7Ym5n7rWTJlIyw?e=I3o8n2


## Manual Testing

Please reference unit-test document for detail testing steps, configuration, commands and logs:
https://a10networks.sharepoint.com/:w:/s/Openstack/ETC9KkK0VThBsY9E-mclFwgBo7FJPPGq7Ym5n7rWTJlIyw?e=I3o8n2