### PR TITLE
[STACK-3247] Proxy Protocol Support

### DIFF
--- a/acos_client/tests/unit/v30/test_slb_virtual_port.py
+++ b/acos_client/tests/unit/v30/test_slb_virtual_port.py
@@ -300,6 +300,7 @@ class TestVirtualPort(unittest.TestCase):
                 "port-number": 80,
                 "template-persist-source-ip": None,
                 "template-persist-cookie": None,
+                "template-tcp-proxy": None,
                 "extended-stats": 1
             }
         }
@@ -434,6 +435,7 @@ class TestVirtualPort(unittest.TestCase):
                     'template-virtual-port': 'template_vp',
                     'template-tcp': None,
                     'template-policy': None,
+                    'template-tcp-proxy': None,
                 }
             }
 
@@ -487,6 +489,7 @@ class TestVirtualPort(unittest.TestCase):
                 'template-persist-source-ip': 'test_s_pers_template',
                 'udp_template': 'test_udp_template',
                 'use-rcv-hop-for-resp': 1,
+                'template-tcp-proxy': None,
             }
         }
 
@@ -541,6 +544,7 @@ class TestVirtualPort(unittest.TestCase):
                 'template-persist-source-ip': 'test_s_pers_template',
                 'udp_template': 'test_udp_template',
                 'use-rcv-hop-for-resp': 1,
+                'template-tcp-proxy': None,
             }
         }
 
@@ -592,6 +596,7 @@ class TestVirtualPort(unittest.TestCase):
                 'template-persist-cookie': 'test_c_pers_template',
                 'template-persist-source-ip': 'test_s_pers_template',
                 'use-rcv-hop-for-resp': 1,
+                'template-tcp-proxy': None,
             }
         }
         kwargs = {
@@ -648,7 +653,8 @@ class TestVirtualPort(unittest.TestCase):
                     'template-persist-cookie': 'test_c_pers_template',
                     'template-persist-source-ip': 'test_s_pers_template',
                     'udp_template': 'test_udp_template',
-                    'template-virtual-port': 'template_vp'
+                    'template-virtual-port': 'template_vp',
+                    'template-tcp-proxy': None,
                 }
             }
         else:
@@ -671,7 +677,8 @@ class TestVirtualPort(unittest.TestCase):
                     'template-persist-cookie': 'test_c_pers_template',
                     'template-persist-source-ip': 'test_s_pers_template',
                     'udp_template': 'test_udp_template',
-                    'template-virtual-port': 'template_vp'
+                    'template-virtual-port': 'template_vp',
+                    'template-tcp-proxy': None,
                 }
             }
         resp = self.client.slb.virtual_server.vport.update(
@@ -728,7 +735,8 @@ class TestVirtualPort(unittest.TestCase):
                 'template-persist-cookie': 'test_c_pers_template',
                 'template-persist-source-ip': 'test_s_pers_template',
                 'udp_template': 'test_udp_template',
-                'template-virtual-port': 'template_vp'
+                'template-virtual-port': 'template_vp',
+                'template-tcp-proxy': None,
             }
         }
         resp = self.client.slb.virtual_server.vport.update(
@@ -784,6 +792,7 @@ class TestVirtualPort(unittest.TestCase):
                 'template-persist-source-ip': 'test_s_pers_template',
                 'udp_template': 'test_udp_template',
                 'use-rcv-hop-for-resp': 1,
+                'template-tcp-proxy': None,
             }
         }
 
@@ -838,6 +847,7 @@ class TestVirtualPort(unittest.TestCase):
                 'template-persist-source-ip': 'test_s_pers_template',
                 'udp_template': 'test_udp_template',
                 'use-rcv-hop-for-resp': 1,
+                'template-tcp-proxy': None,
             }
         }
 
@@ -893,6 +903,7 @@ class TestVirtualPort(unittest.TestCase):
                     'template-persist-cookie': 'test_c_pers_template',
                     'template-persist-source-ip': 'test_s_pers_template',
                     'udp_template': 'test_udp_template',
+                    'template-tcp-proxy': None,
                     'template-virtual-port': 'template_vp'
                 }
             }
@@ -973,7 +984,8 @@ class TestVirtualPort(unittest.TestCase):
                 'template-persist-cookie': 'test_c_pers_template',
                 'template-persist-source-ip': 'test_s_pers_template',
                 'udp_template': 'test_udp_template',
-                'template-virtual-port': 'template_vp'
+                'template-virtual-port': 'template_vp',
+                'template-tcp-proxy': None,
             }
         }
         resp = self.client.slb.virtual_server.vport.replace(

--- a/acos_client/v30/slb/__init__.py
+++ b/acos_client/v30/slb/__init__.py
@@ -20,6 +20,7 @@ from acos_client.v30.slb.hm import HealthMonitor
 from acos_client.v30.slb.server import Server
 from acos_client.v30.slb.service_group import ServiceGroup
 from acos_client.v30.slb.template import Template
+from acos_client.v30.slb.tcp_proxy import TcpProxy
 from acos_client.v30.slb.virtual_server import VirtualServer
 
 
@@ -51,6 +52,10 @@ class SLB(base.BaseV30):
     @property
     def aflex_policy(self):
         return AFlexPolicy(self.client)
+
+    @property
+    def tcp_proxy(self):
+        return TcpProxy(self.client)
 
     @property
     def common(self):

--- a/acos_client/v30/slb/aflex_policy.py
+++ b/acos_client/v30/slb/aflex_policy.py
@@ -38,7 +38,6 @@ class AFlexPolicy(base.BaseV30):
 
         obj_params = {
             "file": file,
-            "size": size,
             "file-handle": file,
             "action": action,
         }

--- a/acos_client/v30/slb/tcp_proxy.py
+++ b/acos_client/v30/slb/tcp_proxy.py
@@ -1,0 +1,63 @@
+# Copyright 2019,  Omkar Telee,  A10 Networks.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import six
+
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
+
+
+class TcpProxy(base.BaseV30):
+
+    # Proxy Protocol Version
+    PROXY = "v1"
+    PROXYV2 = "v2"
+
+    url_prefix = '/slb/template/tcp-proxy/'
+
+    def get(self, name, **kwargs):
+        return self._get(self.url_prefix + name, **kwargs)
+
+    def exists(self, name, **kwargs):
+        try:
+            self.get(name, **kwargs)
+            return True
+        except acos_errors.NotFound:
+            return False
+
+    def _set(self, name, version, **kwargs):
+
+        params = {
+            "tcp-proxy":{
+                "name": name,
+                "proxy-header": {
+                    "proxy-header-action": "insert",
+                    "version": version
+                }
+            }
+        }
+
+        response = self._post(self.url_prefix, params, **kwargs)
+        return response
+
+    def create(self, name, version, **kwargs):
+        return self._set(name, version, **kwargs)
+
+    def update(self, name, version, **kwargs):
+        return self._set(name, version, **kwargs)
+
+    def delete(self, name):
+        return self._delete(self.url_prefix + name)

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -94,6 +94,7 @@ class VirtualPort(base.BaseV30):
         template_client_ssl=None,
         sampling_enable=None,
         aflex_scripts=None,
+        aflex_scripts_clear=False,
         tcp_proxy_name=None,
         **kwargs
     ):
@@ -173,6 +174,8 @@ class VirtualPort(base.BaseV30):
 
         if aflex_scripts is not None:
             params['port']['aflex-scripts'] = aflex_scripts
+        elif aflex_scripts_clear:
+            params['port']['aflex-scripts'] = None
 
         if update:
             url += self.format_vport_url(port_number=protocol_port, protocol=protocol)
@@ -265,6 +268,7 @@ class VirtualPort(base.BaseV30):
         template_client_ssl=None,
         sampling_enable=None,
         aflex_scripts=None,
+        aflex_scripts_clear=False,
         tcp_proxy_name=None,
         **kwargs
     ):
@@ -301,6 +305,7 @@ class VirtualPort(base.BaseV30):
                 template_client_ssl=template_client_ssl,
                 sampling_enable=sampling_enable,
                 aflex_scripts=aflex_scripts,
+                aflex_scripts_clear=aflex_scripts_clear,
                 tcp_proxy_name=tcp_proxy_name,
                 **kwargs
             )
@@ -330,6 +335,7 @@ class VirtualPort(base.BaseV30):
                 template_client_ssl=template_client_ssl,
                 sampling_enable=sampling_enable,
                 aflex_scripts=aflex_scripts,
+                aflex_scripts_clear=aflex_scripts_clear,
                 tcp_proxy_name=tcp_proxy_name,
                 **kwargs
             )
@@ -361,6 +367,7 @@ class VirtualPort(base.BaseV30):
         template_client_ssl=None,
         sampling_enable=None,
         aflex_scripts=None,
+        aflex_scripts_clear=False,
         tcp_proxy_name=None,
         **kwargs
     ):
@@ -392,6 +399,7 @@ class VirtualPort(base.BaseV30):
             template_client_ssl=template_client_ssl,
             sampling_enable=sampling_enable,
             aflex_scripts=aflex_scripts,
+            aflex_scripts_clear=aflex_scripts_clear,
             tcp_proxy_name=tcp_proxy_name,
             **kwargs)
         return self._post(url, params, max_retries=max_retries, timeout=timeout, axapi_args=kwargs)

--- a/acos_client/v30/slb/virtual_port.py
+++ b/acos_client/v30/slb/virtual_port.py
@@ -94,6 +94,7 @@ class VirtualPort(base.BaseV30):
         template_client_ssl=None,
         sampling_enable=None,
         aflex_scripts=None,
+        tcp_proxy_name=None,
         **kwargs
     ):
         exclude_minimize = [] if exclude_minimize is None else exclude_minimize
@@ -105,6 +106,7 @@ class VirtualPort(base.BaseV30):
                 "port-number": int(protocol_port),
                 "template-persist-source-ip": s_pers_name,
                 "template-persist-cookie": c_pers_name,
+                "template-tcp-proxy": tcp_proxy_name,
                 "extended-stats": status
             }, exclude=exclude_minimize
             )
@@ -202,6 +204,7 @@ class VirtualPort(base.BaseV30):
         template_client_ssl=None,
         sampling_enable=None,
         aflex_scripts=None,
+        tcp_proxy_name=None,
         **kwargs
     ):
 
@@ -232,6 +235,7 @@ class VirtualPort(base.BaseV30):
             template_client_ssl=template_client_ssl,
             sampling_enable=sampling_enable,
             aflex_scripts=aflex_scripts,
+            tcp_proxy_name=tcp_proxy_name,
             **kwargs
         )
 
@@ -261,6 +265,7 @@ class VirtualPort(base.BaseV30):
         template_client_ssl=None,
         sampling_enable=None,
         aflex_scripts=None,
+        tcp_proxy_name=None,
         **kwargs
     ):
 
@@ -268,7 +273,7 @@ class VirtualPort(base.BaseV30):
         if vp is None:
             raise ae.NotFound()
 
-        exclude = ['template-persist-source-ip', 'template-persist-cookie']
+        exclude = ['template-persist-source-ip', 'template-persist-cookie', 'template-tcp-proxy']
 
         try:
             url, params, kwargs = self._set(
@@ -296,6 +301,7 @@ class VirtualPort(base.BaseV30):
                 template_client_ssl=template_client_ssl,
                 sampling_enable=sampling_enable,
                 aflex_scripts=aflex_scripts,
+                tcp_proxy_name=tcp_proxy_name,
                 **kwargs
             )
         except ae.AxapiJsonFormatError:
@@ -324,6 +330,7 @@ class VirtualPort(base.BaseV30):
                 template_client_ssl=template_client_ssl,
                 sampling_enable=sampling_enable,
                 aflex_scripts=aflex_scripts,
+                tcp_proxy_name=tcp_proxy_name,
                 **kwargs
             )
         return url, params, kwargs
@@ -354,6 +361,7 @@ class VirtualPort(base.BaseV30):
         template_client_ssl=None,
         sampling_enable=None,
         aflex_scripts=None,
+        tcp_proxy_name=None,
         **kwargs
     ):
 
@@ -384,6 +392,7 @@ class VirtualPort(base.BaseV30):
             template_client_ssl=template_client_ssl,
             sampling_enable=sampling_enable,
             aflex_scripts=aflex_scripts,
+            tcp_proxy_name=tcp_proxy_name,
             **kwargs)
         return self._post(url, params, max_retries=max_retries, timeout=timeout, axapi_args=kwargs)
 
@@ -413,6 +422,7 @@ class VirtualPort(base.BaseV30):
         template_client_ssl=None,
         sampling_enable=None,
         aflex_scripts=None,
+        tcp_proxy_name=None,
         **kwargs
     ):
 
@@ -443,6 +453,7 @@ class VirtualPort(base.BaseV30):
             template_client_ssl=template_client_ssl,
             sampling_enable=sampling_enable,
             aflex_scripts=aflex_scripts,
+            tcp_proxy_name=tcp_proxy_name,
             **kwargs)
         return self._put(url, params, max_retries=max_retries, timeout=timeout, axapi_args=kwargs)
 


### PR DESCRIPTION
## Description
Proxy Protocol Support
Story: https://a10networks.atlassian.net/browse/STACK-3247


## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3247

## Technical Approach

- Support PROXY and PROXYV2 protocol for a10-octavia pool
- a10-octavia need to consider the proxy protocol support on ACOS versions. Proxy protocol is officially supported on ACOS 5.2.1, but it can also be configured on 4.1.4. Therefore,
  - by default: a10-octavia will configure the proxy-header insert v1/v2 in tcp proxy template and bind to vport for PROXY/PROXYV2 pool. 
  - But provide an option (i.e. use_aflex_proxy) for user to choose use aFlex to configure PROXY protocol (v1) on TCP vport in Thunder.
- a10-octavia should maintain tcp-proxy template and aFlex script properly and deleted when it is no longer needed.


Please check details in design document: https://a10networks.sharepoint.com/:w:/s/Openstack/Ecto3CVxEP5CvDkK5uJE1MUBQu_b0UKppgYnEHpEE1wD6Q?e=y8rBWv


## Config Changes
<pre>
<b>[service_group]
use_aflex_proxy = True
</b>
</pre>


## Test Cases

- Rack Flow basic
Proxy V1 pools Create
Proxy V2 pools Create
Proxy V1 pools with aFlex Create
Proxy V1 pools Delete
Proxy V2 pools Delete
Proxy V1 pools with aFlex Delete
Proxy V1 pools cascade deletion
Proxy V2 pools cascade deletion
Proxy V1 pools with aFlex cascade delete
Proxy V1 pools and Proxy V1 pools with aFlex create
Proxy V1 pools and Proxy V1 pools with aFlex delete (delete proxy first)
Proxy V1 pools and Proxy V1 pools with aFlex delete (delete aflex proxy first)
Proxy V1 pools and Proxy V1 pools with aFlex cascade delete

- vThunder Flow
Proxy V1 pools Create
Proxy V2 pools Create
Proxy V1 pools with aFlex Create
Proxy V1 pools Delete
Proxy V2 pools Delete
Proxy V1 pools with aFlex Delete
Proxy V1 pools cascade delete
Proxy V2 pools cascade delete
Proxy V1 pools with aFlex cascade delete
Proxy V1 pools and Proxy V1 pools with aFlex create
Proxy V1 pools and Proxy V1 pools with aFlex delete
Proxy V1 pools and Proxy V1 pools with aFlex cascade delete

- Fully Populated with Proxy Protocol
Rack flow Proxy V1 pools Create
Rack flow Proxy V2 pools Create
Rack flow Proxy V1 pools with aFlex Create
vThunder flow Proxy V1 pools Create
vThunder flow Proxy V2 pools Create
vThunder flow Proxy V1 pools with aFlex Create

- Traffic Test
Proxy Protocol
Proxy Protocol V2
Porxy Protocol with aFlex

Please check unit-test document for details: https://a10networks.sharepoint.com/:w:/s/Openstack/Efq-YrNuXNVJrbeiF0h_k-UB_msQhUOweJRncRvzCY_LmQ?e=KT84pH

## Manual Testing
Please check unit-test document for details: https://a10networks.sharepoint.com/:w:/s/Openstack/Efq-YrNuXNVJrbeiF0h_k-UB_msQhUOweJRncRvzCY_LmQ?e=KT84pH
