### PR TITLE
[STACK-3375] Fix health monitor missing

### DIFF
--- a/acos_client/v30/slb/server.py
+++ b/acos_client/v30/slb/server.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from acos_client import errors as acos_errors
 from acos_client.v30 import base
 from acos_client.v30.slb.port import Port
 
@@ -25,6 +26,13 @@ class Server(base.BaseV30):
     def get(self, name, max_retries=None, timeout=None, **kwargs):
         return self._get(self.url_prefix + name, max_retries=max_retries, timeout=timeout,
                          axapi_args=kwargs)
+
+    def exists(self, name):
+        try:
+            self.get(name)
+            return True
+        except acos_errors.NotFound:
+            return False
 
     def get_all(self):
         return self._get(self.url_prefix)


### PR DESCRIPTION
## Description
- Required: Severity Level: Critical
- Required: Issue Description:
Health Monitor will not configured on slb servers if Health Monitor creation command is after the member creation commands.
This is introduced after: https://github.com/a10networks/a10-octavia/pull/560/files
Previously we have logic to update service-group health monitor. But when move hm from service-group to slb server. We didn't implement the logic for membre.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3375

## Technical Approach
For CreateAndAssociateHealthMonitor(), we need to update members in the pool with the health monitor.

## Config Changes


<pre>
<b>N/A</b>
</pre>


## Test Cases
- verify commands:
```
openstack loadbalancer create --vip-subnet-id tp91 --name vip1
openstack loadbalancer listener create --protocol HTTP --protocol-port 80 --name vport1 vip1
openstack loadbalancer pool create --protocol HTTP --lb-algorithm SOURCE_IP_PORT --listener vport1 --name pool1
openstack loadbalancer member create --address 192.168.90.18 --protocol-port 8080 pool1
openstack loadbalancer healthmonitor create --delay 30 --timeout 3 --max-retries 3 --type HTTP pool1 --name hm1
openstack loadbalancer member create --address 192.168.90.19 --protocol-port 8080 pool1
```

## Manual Testing

- result:
```
health monitor 6a499b2b-f2de-45d0-b5c6-d6e108ff5cb6
  override-port 80
  interval 30 timeout 3
  method http port 80 expect response-code 200 url GET /
!
slb server ecc25_192_168_90_18 192.168.90.18
  health-check 6a499b2b-f2de-45d0-b5c6-d6e108ff5cb6
  port 8080 tcp
!
slb server ecc25_192_168_90_19 192.168.90.19
  health-check 6a499b2b-f2de-45d0-b5c6-d6e108ff5cb6
  port 8080 tcp
!
slb service-group a10fc2c3-c321-4c73-8416-e7777e490f91 tcp
  method src-ip-hash
  member ecc25_192_168_90_18 8080
  member ecc25_192_168_90_19 8080
!
slb virtual-server 36cb4911-8546-4ff0-bd7b-f482318b2d22 192.168.91.78
  port 80 http
    name 5c3932b2-edba-4b16-b110-b77e8dd20b81
    extended-stats
    source-nat auto
    service-group a10fc2c3-c321-4c73-8416-e7777e490f91
```
