### PR TITLE
[STACK-3374] health monitor request may affected by previous operation

### DIFF
--- a/acos_client/v30/slb/hm.py
+++ b/acos_client/v30/slb/hm.py
@@ -75,7 +75,7 @@ class HealthMonitor(base.BaseV30):
                 "interval": int(hm_interval),
                 "timeout": int(hm_timeout),
                 "method": {
-                    mon_method: self._method_objects[mon_method]
+                    mon_method: dict(self._method_objects[mon_method])
                 },
                 "override-ipv4": ipv4
             }


### PR DESCRIPTION
Servility: Hight
Description: acos-client Health Monitor use a global _method_objects dictionary for all hm request. And every request will change it. There are two issue for this:
- previous request parameter still keep in it. and
- it is not thread-safe, if 2 request running at the same time. Two operation will both make change on it and the result it unpredictable. 

Issue: https://a10networks.atlassian.net/browse/STACK-3374

Solution:
- when init the param, return a copy of _method_objects intead of a _method_objects reference.

Test:
1. run the script:
```
#!/bin/sh
set -e
subnet_id=$(openstack subnet show tp91 -c id -f value)
TOKEN=$(openstack token issue -f value -c id)
OCTAVIA_BASE_URL=$(openstack endpoint list --service load-balancer --interface public -c URL -f value)
cat <<EOF > hm_https.json
{
    "loadbalancer": {
        "name": "vip1",
        "vip_subnet_id": "$subnet_id",
        "provider": "a10",
        "listeners": [
            {
                "name": "vport1",
                "protocol": "TCP",
                "protocol_port": 80,
                "default_pool": {
                    "name": "pool1",
                    "protocol": "TCP",
                    "lb_algorithm": "ROUND_ROBIN",
                    "healthmonitor": {
                        "name": "hm1",
                        "type": "HTTPS",
                        "delay": "3",
                        "max_retries": 2,
                        "timeout": 1,
                        "http_method": "GET",
                        "expected_codes": "200" ,
                        "url_path" : "/ab/cd/ef"
                    }
                }
            },
            {
                "name": "vport2",
                "protocol": "HTTP",
                "protocol_port": 8047,
                "default_pool": {
                    "name": "pool2",
                    "protocol": "HTTP",
                    "lb_algorithm": "ROUND_ROBIN",
                    "healthmonitor": {
                        "name": "hm2",
                        "type": "HTTPS",
                        "delay": "3",
                        "max_retries": 2,
                        "timeout": 1,
                        "http_method": "POST",
                        "expected_codes": "200",
                        "url_path" : "/ab/cd/ef"
                    }
                }
            },
            {
                "name": "vport3",
                "protocol": "HTTPS",
                "protocol_port": 82,
                "default_pool": {
                    "name": "pool3",
                    "protocol": "HTTPS",
                    "lb_algorithm": "ROUND_ROBIN",
                    "healthmonitor": {
                        "type": "HTTPS",
                        "delay": "3",
                        "max_retries": 2,
                        "timeout": 1,
                        "http_method": "HEAD",
                        "expected_codes": "200",
                        "url_path" : "/ab/cd/ef"
                    }
                }
            }
        ]
    }
}
EOF
echo curl -X POST -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -d @hm_https.json ${OCTAVIA_BASE_URL}/v2.0/lbaas/loadbalancers
echo "........."
echo ""
curl -v -X POST -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -d @hm_https.json ${OCTAVIA_BASE_URL}/v2.0/lbaas/loadbalancers

```

2. result:
```
health monitor octavia_health_monitor
  retry 5
  override-ipv4 192.168.0.164
  interval 20 timeout 3
  method udp port 5550
!
health monitor 70e20252-0053-48df-8554-a45baab69ea6
  retry 2
  interval 3 timeout 1
  method https port 443 expect response-code 200 url HEAD /ab/cd/ef
!
health monitor 0db16888-878b-40a3-84d4-265f27c52ec1
  retry 2
  interval 3 timeout 1
  method https port 443 expect response-code 200 url GET /ab/cd/ef
!
health monitor 9fd3f045-6333-43ee-8cad-e2fab9c9a9ab
  retry 2
  interval 3 timeout 1
  method https port 443 expect response-code 200 url POST /ab/cd/ef postdata 0123456789
!
slb server octavia_health_manager_controller 192.168.0.164
  health-check octavia_health_monitor
!
slb service-group 12ea4789-7a89-446f-8c55-37f850409014 tcp
!
slb service-group 26384039-9bf9-4141-acb4-1b148a04205a tcp
!
slb service-group f43882dc-3820-4fc0-acc9-f5ddede8d9ee tcp
!
slb virtual-server fcd0eb9e-3096-4603-b35a-5653cbad72f9 192.168.91.204
  port 80 tcp
    name 4e90a68d-e19a-4e0b-a04f-47b74d8ad783
    extended-stats
    source-nat auto
    service-group 26384039-9bf9-4141-acb4-1b148a04205a
  port 82 tcp
    name 719d39a4-34d9-4cb3-82b1-dc2b5624d2d2
    extended-stats
    source-nat auto
    service-group 12ea4789-7a89-446f-8c55-37f850409014
  port 8047 http
    name f98671e7-be26-454a-89ce-f7ca58a5634d
    extended-stats
    source-nat auto
    service-group f43882dc-3820-4fc0-acc9-f5ddede8d9ee
!
```