### PR TITLE
Added policy template list for v21

### DIFF
--- a/acos_client/v21/slb/template/__init__.py
+++ b/acos_client/v21/slb/template/__init__.py
@@ -18,6 +18,7 @@ from acos_client.v21.slb.template.persistence import CookiePersistence
 from acos_client.v21.slb.template.persistence import SourceIpPersistence
 from acos_client.v21.slb.template.template_ssl import ClientSSL
 from acos_client.v21.slb.template.template_ssl import ServerSSL
+from acos_client.v21.slb.template.templates import PolicyTemplates
 
 
 class Template(base.BaseV21):
@@ -37,3 +38,7 @@ class Template(base.BaseV21):
     @property
     def src_ip_persistence(self):
         return SourceIpPersistence(self.client)
+
+    @property
+    def policy_templates(self):
+        return PolicyTemplates(self.client)

--- a/acos_client/v21/slb/template/templates.py
+++ b/acos_client/v21/slb/template/templates.py
@@ -1,0 +1,25 @@
+# Copyright 2014,  Doug Wiegley,  A10 Networks.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from acos_client.v21 import base
+
+
+class BaseTemplate(base.BaseV21):
+
+    def all(self, **kwargs):
+        return self._get("slb.template.%s.getall" % self.template_type, **kwargs)
+
+
+class PolicyTemplates(BaseTemplate):
+    template_type = "pbslb"


### PR DESCRIPTION
Added policy template list for v21.
It already exists in v30.
https://github.com/a10networks/acos-client/blob/master/acos_client/v30/slb/template/templates.py

*Support for v21 has ended, but I would like to ask for confirmation.