### PR TITLE
Updated version to 2.10.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,18 @@
 ---------------------------
 acos-client CHANGELOG
 ---------------------------
+* 2.10.0
+- Added InterfaceVE object for CRUD on Virtual Ethernet interfaces for v30
+- Added ClassList object for CRUD on Class Lists for v30
+- Added Router/BGP object for CRUD on bgp section for v30
+- Added more unittests to cover the new addition
 
 acos-client. Changes tracked from 1.4.2 > onward
 * 1.4.7
 - Added IPv6 support for aXAPI v21 and v30 as well as IPv6 test cases
 - Updated ACOS response messages
 - IPv6 enhancements to t.py
-- Improved t.py error handling and better support for aXAPI v2.1 
+- Improved t.py error handling and better support for aXAPI v2.1
 
 
 * 1.4.6

--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -53,6 +53,8 @@ from acos_client.v30.slb import SLB as v30_SLB
 from acos_client.v30.system import System as v30_System
 from acos_client.v30.vlan import Vlan as v30_Vlan
 from acos_client.v30.vrrpa.vrid import VRID as v30_VRRPA
+from acos_client.v30.router import Router as v30_Router
+from acos_client.v30.class_list import ClassList as v30_ClassList
 
 VERSION_IMPORTS = {
     '21': {
@@ -80,6 +82,7 @@ VERSION_IMPORTS = {
         'Network': v30_Network,
         'Overlay': v30_Overlay,
         'RIB': v30_RIB,
+        'Router': v30_Router,
         'Session': v30_Session,
         'SFlow': v30_SFlow,
         'SLB': v30_SLB,
@@ -90,6 +93,7 @@ VERSION_IMPORTS = {
         'DeviceContext': v30_DeviceContext,
         'Flexpool': Flexpool,
         'Delete': Delete,
+        'ClassList': v30_ClassList,
     },
 }
 
@@ -121,6 +125,9 @@ class Client(object):
         )
         self.session = VERSION_IMPORTS[self._version]['Session'](self, username, password)
         self.current_partition = 'shared'
+
+    def __str__(self):
+        return f"Client: {vars(self)}"
 
     def _just_digits(self, s):
         return ''.join(i for i in str(s) if i.isdigit())
@@ -187,12 +194,21 @@ class Client(object):
         return VERSION_IMPORTS[self._version]["RIB"](self)
 
     @property
+    def router(self):
+        return VERSION_IMPORTS[self._version]["Router"](self)
+
+
+    @property
     def vrrpa(self):
         return VERSION_IMPORTS[self._version]["VRRPA"](self)
 
     @property
     def device_context(self):
         return VERSION_IMPORTS[self._version]["DeviceContext"](self)
+
+    @property
+    def class_list(self):
+        return VERSION_IMPORTS[self._version]["ClassList"](self)
 
     @property
     def delete(self):
@@ -211,3 +227,4 @@ class Client(object):
                 break
             except socket.error:
                 pass
+

--- a/acos_client/tests/unit/v30/test_base.py
+++ b/acos_client/tests/unit/v30/test_base.py
@@ -1,0 +1,132 @@
+# Copyright (C) 2022, A10 Networks Inc. All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
+
+from acos_client.v30.base import BaseV30
+
+
+class TestChildClass(BaseV30):
+    def __init__(self, client):
+        super(TestChildClass, self).__init__(client=client)
+        self.url_prefix = "/url/prefix/"
+
+
+class TestBaseV30Child(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.client = mock.MagicMock()
+        self.child_cls = TestChildClass(client=self.client)
+        self.url_prefix = "/url/prefix"
+
+    def test_build_url(self):
+        cases = [{
+            "case_name": "arbitrary arguments",
+            "args": ["first"],
+            "kwargs": {},
+            "expected": f"{self.url_prefix}/first"
+        }, {
+            "case_name": "arbitrary arguments and should end with separator",
+            "args": ["first"],
+            "kwargs": {"ends_with_separator": True},
+            "expected": f"{self.url_prefix}/first/"
+        }, {
+            "case_name": "arbitrary arguments with empty string and None",
+            "args": ["first", "", None, "second"],
+            "kwargs": {},
+            "expected": f"{self.url_prefix}/first/second"
+        }, {
+            "case_name": "arbitrary arguments and with slashes",
+            "args": ["first", "/second/", "/third", "last"],
+            "kwargs": {"ends_with_separator": True},
+            "expected": f"{self.url_prefix}/first/second/third/last/"
+        }, {
+            "case_name": "arbitrary arguments and leading slash",
+            "args": ["/suffix_with_leading_slash"],
+            "kwargs": {},
+            "expected": f"{self.url_prefix}/suffix_with_leading_slash"
+        }, {
+            "case_name": "keyword argument suffix with leading slash",
+            "args": [],
+            "kwargs": {"suffix": "/suffix_with_leading_slash"},
+            "expected": f"{self.url_prefix}/suffix_with_leading_slash"
+        }, {
+            "case_name": "arbitrary and keyword arguments where only arbitrary args will be processed",
+            "args": ["end", "result"],
+            "kwargs": {"middle": "middle", "suffix": "suffix"},
+            "expected": f"{self.url_prefix}/end/result"
+        }, {
+            "case_name": "keyword arguments suffix and middle",
+            "args": [],
+            "kwargs": {"middle": "middle", "suffix": "suffix"},
+            "expected": f"{self.url_prefix}/middle/suffix"
+        }, {
+            "case_name": "keyword arguments suffix and middle with slashes",
+            "args": [],
+            "kwargs": {"middle": "/middle_with_slashes/", "suffix": "/suffix_with_slashes/"},
+            "expected": f"{self.url_prefix}/middle_with_slashes/suffix_with_slashes"
+        }, {
+            "case_name": "keyword arguments suffix and middle with slashes",
+            "args": [],
+            "kwargs": {"middle": "/middle_with_slashes/", "suffix": "/suffix_with_slashes/", "ends_with_separator": True},
+            "expected": f"{self.url_prefix}/middle_with_slashes/suffix_with_slashes/"
+        }, {
+            "case_name": "arbitrary arguments with slashes",
+            "args": ["/first_with_slashes/", "/second_with_slashes/"],
+            "kwargs": {},
+            "expected": f"{self.url_prefix}/first_with_slashes/second_with_slashes"
+        }, {
+            "case_name": "arbitrary arguments with slashes should end with separator",
+            "args": ["/first/with/slashes/", "/second/with/slashes/"],
+            "kwargs": {"ends_with_separator": True},
+            "expected": f"{self.url_prefix}/first/with/slashes/second/with/slashes/"
+        }, {
+            "case_name": "keyword arguments with slashes",
+            "args": [],
+            "kwargs": {"middle": "middle/with/slash", "suffix": "suffix/with/slash/"},
+            "expected": f"{self.url_prefix}/middle/with/slash/suffix/with/slash"
+        }, {
+            "case_name": "keyword arguments with slashes should end with separator",
+            "args": [],
+            "kwargs": {"middle": "middle/with/slash", "suffix": "suffix/with/slash/", "ends_with_separator": True},
+            "expected": f"{self.url_prefix}/middle/with/slash/suffix/with/slash/"
+        }]
+        for case in cases:
+            expected_url = case["expected"]
+            actual_url = self.child_cls._build_url(*case["args"], **case["kwargs"])
+            self.assertEqual(expected_url, actual_url)
+
+    def test_convert_to_int(self):
+        cases = [
+            {"param": 1, "expected_return": 0, "case_name": "int 1 is passed"},
+            {"param": 0, "expected_return": 0, "case_name": "int 0 is passed"},
+            {"param": True, "expected_return": 1, "case_name": "True is passed"},
+            {"param": False, "expected_return": 0, "case_name": "False is passed"},
+            {"param": "str_value", "expected_return": 0, "case_name": "string is passed"},
+            {"param": "", "expected_return": 0, "case_name": "empty string is passed"},
+            {"param": None, "expected_return": 0, "case_name": "None is passed"},
+            {"param": [], "expected_return": 0, "case_name": "empty list is passed"},
+            {"param": {}, "expected_return": 0, "case_name": "empty dict is passed"},
+        ]
+        for case in cases:
+            ret_val = BaseV30.convert_to_int(case["param"])
+            self.assertIs(case["expected_return"], ret_val)

--- a/acos_client/tests/unit/v30/test_class_list.py
+++ b/acos_client/tests/unit/v30/test_class_list.py
@@ -1,0 +1,146 @@
+# Copyright (C) 2022, A10 Networks Inc. All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
+
+from acos_client.v30.class_list import ClassList
+
+class TestClassList(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.client = mock.MagicMock()
+        self.class_list = ClassList(client=self.client)
+        self.url_prefix = "/axapi/v3/class-list"
+        self.name = "class_list_name"
+
+    def test_class_list_get_list(self):
+        self.class_list.get_list()
+        _url = f"{self.url_prefix}"
+        self.client.http.request.assert_called_with(
+            "GET", _url, {}, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )
+        self.class_list.get_all()
+        self.client.http.request.assert_called_with(
+            "GET", _url, {}, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )
+        self.class_list.all()
+        self.client.http.request.assert_called_with(
+            "GET", _url, {}, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )
+
+    def test_class_list_get(self):
+        _url = f"{self.url_prefix}/{self.name}"
+        self.class_list.get(self.name)
+        self.client.http.request.assert_called_with(
+            "GET", _url, {}, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )
+
+    def test_class_list_create(self):
+        _url = f"{self.url_prefix}"
+        self.class_list.create(self.name, ipv4addr="192.168.1.1/32", lsn_lid=5, ipv6_addr="fe80::1/64", v6_lsn_lid=2)
+        expected_payload = {
+            "class-list" : {
+                "name": self.name,
+                "file": 0,
+                "ipv4-list": [{"ipv4addr": "192.168.1.1/32", "lsn-lid": 5}],
+            }
+        }
+        self.client.http.request.assert_called_with(
+            "POST", _url, expected_payload, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )
+
+    def test_class_list_create_without_lsn_lid(self):
+        _url = f"{self.url_prefix}"
+        self.class_list.create(self.name, ipv4addr="192.168.1.1/32")
+        expected_payload = {
+            "class-list" : {
+                "name": self.name,
+                "file": 0,
+                "ipv4-list": [{"ipv4addr": "192.168.1.1/32"}],
+            }
+        }
+        self.client.http.request.assert_called_with(
+            "POST", _url, expected_payload, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )
+
+    def test_class_list_create_v6(self):
+        _url = f"{self.url_prefix}"
+        self.class_list.create(self.name, ipv6_addr="fe80::1/64", v6_lsn_lid=2)
+        expected_payload = {
+            "class-list" : {
+                "name": self.name,
+                "file": 0,
+                "ipv6-list": [{"ipv6-addr": "fe80::1/64", "v6-lsn-lid": 2}],
+            }
+        }
+        self.client.http.request.assert_called_with(
+            "POST", _url, expected_payload, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )
+
+    def test_class_list_create_v6_without_lsn_lid(self):
+        _url = f"{self.url_prefix}"
+        self.class_list.create(self.name, ipv6_addr="fe80::1/64")
+        expected_payload = {
+            "class-list" : {
+                "name": self.name,
+                "file": 0,
+                "ipv6-list": [{"ipv6-addr": "fe80::1/64"}],
+            }
+        }
+        self.client.http.request.assert_called_with(
+            "POST", _url, expected_payload, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )
+
+    def test_class_list_update(self):
+        _url = f"{self.url_prefix}/{self.name}"
+        self.class_list.update(self.name, file=True, ipv4addr="192.168.1.0/28", lsn_lid=10)
+        expected_payload = {
+            "class-list" : {
+                "name": self.name,
+                "file": 1,
+                "ipv4-list": [{"ipv4addr": "192.168.1.0/28", "lsn-lid": 10}],
+            }
+        }
+        self.client.http.request.assert_called_with(
+            "POST", _url, expected_payload, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )
+
+    def test_class_list_update_v6(self):
+        _url = f"{self.url_prefix}"
+        self.class_list.create(self.name, ipv6_addr="fe80::1/128", v6_lsn_lid=10)
+        expected_payload = {
+            "class-list" : {
+                "name": self.name,
+                "file": 0,
+                "ipv6-list": [{"ipv6-addr": "fe80::1/128", "v6-lsn-lid": 10}],
+            }
+        }
+        self.client.http.request.assert_called_with(
+            "POST", _url, expected_payload, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )
+
+    def test_class_list_delete(self):
+        _url = f"{self.url_prefix}/{self.name}"
+        self.class_list.delete(self.name)
+        self.client.http.request.assert_called_with(
+            "DELETE", _url, {}, mock.ANY, axapi_args=None, max_retries=None, timeout=mock.ANY,
+        )

--- a/acos_client/tests/unit/v30/test_router_bgp.py
+++ b/acos_client/tests/unit/v30/test_router_bgp.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+try:
+    import unittest
+    from unittest import mock
+except ImportError:
+    import mock
+    import unittest2 as unittest
+
+from acos_client.v30.router.bgp import Bgp
+
+class TestRouterBgp(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.client = mock.MagicMock()
+        self.bgp = Bgp(client=self.client)
+        self.url_prefix = "/axapi/v3/router/bgp/"
+        self.bgp_asn = 65123
+
+    def test_bgp_get(self):
+        self.bgp.get_list(asn=self.bgp_asn)
+        _url = f"{self.url_prefix}{self.bgp_asn}/"
+        self.client.http.request.assert_called_with("GET", _url, {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=mock.ANY)
+        self.bgp.get(asn=self.bgp_asn)
+        self.client.http.request.assert_called_with("GET", _url, {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=mock.ANY)
+
+    def test_neighbor_peer_group_get(self):
+        _url_prefix = f"{self.url_prefix}{self.bgp_asn}/neighbor/peer-group-neighbor/"
+        self.bgp.neighbor.peer_group.get_list(asn=self.bgp_asn)
+        self.client.http.request.assert_called_with("GET", _url_prefix, {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=mock.ANY)
+        pg = "TEST"
+        self.bgp.neighbor.peer_group.get(asn=self.bgp_asn, key=pg)
+        self.client.http.request.assert_called_with("GET", f"{_url_prefix}{pg}", {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=mock.ANY)
+
+    def test_neighbor_ipv4_get(self):
+        _url_prefix = f"{self.url_prefix}{self.bgp_asn}/neighbor/ipv4-neighbor/"
+        self.bgp.neighbor.ipv4_neighbor.get_list(asn=self.bgp_asn)
+        self.client.http.request.assert_called_with("GET", _url_prefix, {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=mock.ANY)
+        ipv4 = "1.1.1.1"
+        self.bgp.neighbor.ipv4_neighbor.get(asn=self.bgp_asn, key=ipv4)
+        self.client.http.request.assert_called_with("GET", f"{_url_prefix}{ipv4}", {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=mock.ANY)
+
+    def test_af_peer_group_get(self):
+        _url_prefix = f"{self.url_prefix}{self.bgp_asn}/address-family/ipv6/neighbor/peer-group-neighbor/"
+        self.bgp.address_family.peer_group.get_list(asn=self.bgp_asn)
+        self.client.http.request.assert_called_with("GET", _url_prefix, {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=mock.ANY)
+        pg = "TEST"
+        self.bgp.address_family.peer_group.get(asn=self.bgp_asn, key=pg)
+        self.client.http.request.assert_called_with("GET", f"{_url_prefix}{pg}", {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=mock.ANY)
+
+    def test_af_ipv6_get(self):
+        _url_prefix = f"{self.url_prefix}{self.bgp_asn}/address-family/ipv6/neighbor/ipv6-neighbor/"
+        self.bgp.address_family.ipv6_neighbor.get_list(asn=self.bgp_asn)
+        self.client.http.request.assert_called_with("GET", _url_prefix, {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=mock.ANY)
+        ipv6 = "6001:8080::1"
+        self.bgp.address_family.ipv6_neighbor.get(asn=self.bgp_asn, key=ipv6)
+        self.client.http.request.assert_called_with("GET", f"{_url_prefix}{ipv6}", {}, mock.ANY, axapi_args=None,
+                                                    max_retries=None, timeout=mock.ANY)

--- a/acos_client/v30/base.py
+++ b/acos_client/v30/base.py
@@ -35,6 +35,10 @@ class BaseV30(object):
         self.auth_header['Authorization'] = "A10 %s" % self.client.session.id
         return ("/axapi/v3" + action)
 
+    @property
+    def url_separator(self):
+        return '/'
+
     def _request(self, method, action, params, retry_count=0, max_retries=None,
                  timeout=None, axapi_args=None, **kwargs):
         if retry_count > 24:
@@ -83,3 +87,54 @@ class BaseV30(object):
     def _is_ipv6(self, ip_address):
         validated_ip_address = ipaddress.ip_address(six.text_type(ip_address))
         return isinstance(validated_ip_address, ipaddress.IPv6Address)
+
+    def _add_separator(self, prefix, *, preceding=False, trailing=False):
+        if not isinstance(prefix, str):
+            return prefix
+        if preceding:
+            prefix = prefix if prefix.startswith(self.url_separator) else f"{self.url_separator}{prefix}"
+        if trailing:
+            prefix = prefix if prefix.endswith(self.url_separator) else f"{prefix}{self.url_separator}"
+        return prefix
+
+    def _remove_separator(self, endpoint_url, *, preceding=False, trailing=False):
+        if not isinstance(endpoint_url, str):
+            return endpoint_url
+        if preceding:
+            endpoint_url = endpoint_url[1:] if endpoint_url.startswith(self.url_separator) else endpoint_url
+        if trailing:
+            endpoint_url = endpoint_url[:-1] if endpoint_url.endswith(self.url_separator) else endpoint_url
+        return endpoint_url
+
+    def _build_url(
+        self, *args, prefix=None, middle=None, suffix=None, ends_with_separator=False, starts_with_separator=False,
+    ):
+        """
+        Build url according to given parameters.
+
+        :param args: If given, args is used to build url by separating with `self.url_separator`. If this parameter
+            is provided, `middle` and `suffix` parameters are skipped.
+        :param middle: If provided it will be the middle part of the url by following url prefix.
+        :param suffix: If provided it will be the last part of the url by following url prefix.
+        :param ends_with_separator: If provided, add `self.url_separator` to the end of the built url if not exists.
+        :param starts_with_separator: If provided, add `self.url_separator` to the beginning of the built url if not exists.
+        :param prefix: if provided, used as prefix of the built url, otherwise `self.url_prefix` is used as url prefix.
+        :return: built url
+        """
+        prefix = self.url_prefix if not prefix and hasattr(self, "url_prefix") else prefix
+        raw_parts = args if args else [e for e in [middle, suffix]]  # use args else middle and suffix
+        url_parts = [self._remove_separator(prefix, trailing=True)]  # remove trailing separator if exists
+        url_parts.extend([self._remove_separator(e, trailing=True, preceding=True) for e in raw_parts if e])
+        url = self.url_separator.join([str(i) for i in url_parts])  # it can be int type, i.e.: asn number
+
+        return self._add_separator(url, preceding=starts_with_separator, trailing=ends_with_separator)
+
+    @staticmethod
+    def convert_to_int(bool_val):
+        """
+        Converts `bool_val` parameter to int value. If and only if `bool_val` is boolean type and equals to True,
+        this method returns 1, otherwise 0.
+        :param bool_val: the parameter converted into int value, expected bool type but any type works also.
+        :return: 1 only if `bool_val` is True. Otherwise, returns 0.
+        """
+        return int(bool_val is True)

--- a/acos_client/v30/class_list.py
+++ b/acos_client/v30/class_list.py
@@ -1,0 +1,174 @@
+# Copyright 2022, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from acos_client import errors as acos_errors
+from acos_client.v30 import base
+
+
+class ClassList(base.BaseV30):
+
+    @property
+    def url_prefix(self):
+        return "/class-list"
+
+    def create(self, name, file=False, ipv4addr=None, lsn_lid=None, ipv6_addr=None, v6_lsn_lid=None):
+        """
+        Create class-list into the device.
+        :param name: name of the class-list going to be created
+        :param file: Create/Edit a class-list stored as a file. default 0 and if True 1 else 0
+        :param ipv4addr: ipv4 address for ipv4-list
+        :param lsn_lid: LSN limit ID for ipv4-list
+        :param ipv6_addr: ipv6 address for ipv6-list
+        :param v6_lsn_lid: LSN limit ID for ipv6-list
+        :raise `acos_errors.Exists` when the object exists and no need to create.
+        """
+        payload = self._build_payload(
+            name=name, file=file, ipv4addr=ipv4addr, lsn_lid=lsn_lid, ipv6_addr=ipv6_addr, v6_lsn_lid=v6_lsn_lid
+        )
+
+        return self._post(self._build_url(), payload)
+
+    def get(self, name):
+        """
+        Get class-list config by name.
+        :param name: name of the class-list configured on the device.
+        :raise `acos_errors.NotFound` when the object does not exist and cannot be retrieved.
+        """
+        return self._get(self._build_url(suffix=name))
+
+    def delete(self, name):
+        """
+        Delete class-list config by name.
+        :param name: name of the class-list configured on the device.
+        """
+        return self._delete(self._build_url(suffix=name))
+
+    def replace(self, name, file=False, ipv4addr=None, lsn_lid=None, ipv6_addr=None, v6_lsn_lid=None):
+        """
+        Replace class-list with the given `name`. ipv4 and ipv6 addresses are mutually exclusive because
+        class-list type is determined according to ipv4-list or ipv6-list existence on device configuration.
+
+        :param name: name of the class-list going to be created
+        :param file: Create/Edit a class-list stored as a file. default 0 and if True 1 else 0
+        :param ipv4addr: ipv4 address for ipv4-list
+        :param lsn_lid: LSN limit ID for ipv4-list
+        :param ipv6_addr: ipv6 address for ipv6-list
+        :param v6_lsn_lid: LSN limit ID for ipv6-list
+        :raise `acos_errors.NotFound` when the object does not exist and cannot be updated.
+        """
+        payload = self._build_payload(
+            name=name, file=file, ipv4addr=ipv4addr, lsn_lid=lsn_lid, ipv6_addr=ipv6_addr, v6_lsn_lid=v6_lsn_lid
+        )
+
+        return self._put(self._build_url(suffix=name), payload)
+
+    def update(self, name, file=False, ipv4addr=None, lsn_lid=None, ipv6_addr=None, v6_lsn_lid=None):
+        """
+        Update class-list with the given `name`. ipv4 and ipv6 addresses are mutually exclusive because
+        class-list type is determined according to ipv4-list or ipv6-list existence on device configuration.
+
+        :param name: name of the class-list going to be created
+        :param file: Create/Edit a class-list stored as a file. default 0 and if True 1 else 0
+        :param ipv4addr: ipv4 address for ipv4-list
+        :param lsn_lid: LSN limit ID for ipv4-list
+        :param ipv6_addr: ipv6 address for ipv6-list
+        :param v6_lsn_lid: LSN limit ID for ipv6-list
+        :raise `acos_errors.NotFound` when the object does not exist and cannot be updated.
+        """
+        payload = self._build_payload(
+            name=name, file=file, ipv4addr=ipv4addr, lsn_lid=lsn_lid, ipv6_addr=ipv6_addr, v6_lsn_lid=v6_lsn_lid
+        )
+
+        return self._post(self._build_url(suffix=name), payload)
+
+    def create_or_update(self, name, file=False, ipv4addr=None, lsn_lid=None, ipv6_addr=None, v6_lsn_lid=None):
+        """
+        `self.create` method raises `acos_errors.Exists` when the object exists, so nothing need to create.
+        `self.update` method raises `acos_errors.NotFound` when the object does not found, so nothing needs to be updated.
+        In contrary, this method does not raise any exception. If object exists, it updates config else create it.
+
+        :param name: name of the class-list going to be created
+        :param file: Create/Edit a class-list stored as a file. default 0 and if True 1 else 0
+        :param ipv4addr: ipv4 address for ipv4-list
+        :param lsn_lid: LSN limit ID for ipv4-list
+        :param ipv6_addr: ipv6 address for ipv6-list
+        :param v6_lsn_lid: LSN limit ID for ipv6-list
+        """
+        if self.exists(name):
+            return self.update(
+                name=name, file=file, ipv4addr=ipv4addr, lsn_lid=lsn_lid, ipv6_addr=ipv6_addr, v6_lsn_lid=v6_lsn_lid
+            )
+        else:
+            return self.create(
+                name=name, file=file, ipv4addr=ipv4addr, lsn_lid=lsn_lid, ipv6_addr=ipv6_addr, v6_lsn_lid=v6_lsn_lid
+            )
+
+    def get_list(self):
+        """ Get list of class-list configurations on the device. """
+        return self._get(self._build_url())
+
+    def get_all(self):
+        """ Get list of class-list configurations on the device. Alias of `self.get_list` method"""
+        return self.get_list()
+
+    def all(self):
+        """ Get list of class-list configurations on the device. Alias of `self.get_list` method"""
+        return self.get_list()
+
+    def exists(self, class_list_name):
+        """
+        Check class-list configuration with name `class_list_name` existence on the device.
+
+        :param class_list_name: name of the class-list
+        :return: True if `class_list_name` class-list exists on the device.
+        """
+        try:
+            self.get(class_list_name)
+            return True
+        except acos_errors.NotFound:
+            return False
+
+    def _build_payload(self, name, file=False, ipv4addr=None, lsn_lid=None, ipv6_addr=None, v6_lsn_lid=None):
+        """
+        Build and return the payload dictionary to be used to update or create the class-list on the device.
+
+        :param name: name of the class-list going to be created
+        :param file: Create/Edit a class-list stored as a file. default 0 and if True 1 else 0
+        :param ipv4addr: ipv4 address for ipv4-list
+        :param lsn_lid: LSN limit ID for ipv4-list
+        :param ipv6_addr: ipv6 address for ipv6-list
+        :param v6_lsn_lid: LSN limit ID for ipv6-list
+        :return: payload dictionary to be used to update or create the class-list on the device.
+        """
+        payload = {
+            "class-list" : {
+                "name": name,
+                "file": self.convert_to_int(file),
+            }
+        }
+        if ipv4addr:
+            ipv4_elem = {"ipv4addr": ipv4addr}
+            if lsn_lid:
+                ipv4_elem["lsn-lid"] = lsn_lid
+
+            payload["class-list"]["ipv4-list"] = [ipv4_elem]
+        elif ipv6_addr:
+            ipv6_elem = {"ipv6-addr": ipv6_addr}
+            if v6_lsn_lid:
+                ipv6_elem["v6-lsn-lid"] = v6_lsn_lid
+            payload["class-list"]["ipv6-list"] = [ipv6_elem]
+
+        return payload

--- a/acos_client/v30/interface.py
+++ b/acos_client/v30/interface.py
@@ -17,6 +17,8 @@ from __future__ import unicode_literals
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
 
+from ipaddress import IPv4Interface
+
 
 class Interface(base.BaseV30):
     iftype = "interface"
@@ -197,9 +199,168 @@ class VirtualEthernet(Interface):
         self.iftype = "ve"
         self.url_prefix = "{0}{1}/".format(self.url_prefix, self.iftype)
 
-    def _build_payload(self, **kwargs):
-        # we need to deal with VLAN stuff here
-        rv = super(VirtualEthernet, self)._build_payload(**kwargs)
-        rv[self.iftype] = rv.pop("interface")
+    def create(
+        self,
+        ifnum, name=None,
+        enable=None,
+        ipv4_address=None,
+        dhcp=None,
+        ipv4_nat_inside=None,
+        ipv6_address=None,
+        ipv6_nat_inside=None,
+    ):
+        """
+        CREATE a VE interface with the provided values.
+        Don't forget to create that interface form VLAN config, otherwise
+        will fail to create
+        :param ifnum: Interface number, according with VLAN ID [2-4094]
+        :param name: (Optional) Set the name of the interface
+        :param enable: (Optional) Enable interface
+        :param ipv4_address: (Optional) List of Tuples that stores IPv4 Address and IPv4 Netmask
+            of that interface. E.g ('192.168.255.1', '255.255.255.252')
+            OR List os IPs provided in the <host_ip>/<netmask> format. E.g ["10.1.11.1/24", "12.12.12.12/28"]
+        :param dhcp: (Optional) Enable DHCP on the interface
+        :param ipv4_nat_inside: (Optional) Enable Inside NAT on IPv4
+        :param ipv6_address: (Optional) List of strs that stores IPv6 Addresses info in the
+            following format: 'FE81::1/64'
+        :param ipv6_nat_inside: (Optional) Enable Inside NAT on IPv6
+        """
+        payload = self._build_payload(
+            ifnum=ifnum, name=name,
+            enable=enable,
+            ipv4_address=ipv4_address,
+            dhcp=dhcp,
+            ipv4_nat_inside=ipv4_nat_inside,
+            ipv6_address=ipv6_address,
+            ipv6_nat_inside=ipv6_nat_inside
+        )
+        return self._post(self.url_prefix, payload)
 
+    def update(
+        self,
+        ifnum, name=None,
+        enable=None,
+        ipv4_address=None,
+        dhcp=None,
+        ipv4_nat_inside=None,
+        ipv6_address=None,
+        ipv6_nat_inside=None
+    ):
+        """
+        Update a VE interface with the provided values.
+        Don't forget to create that interface form VLAN config, otherwise
+        will fail to create
+        :param ifnum: Interface number, according with VLAN ID [2-4094]
+        :param name: (Optional) Set the name of the interface
+        :param enable: (Optional) Enable interface
+        :param ipv4_address: (Optional) List of Tuples that stores IPv4 Address and IPv4 Netmask
+            of that interface. E.g ('192.168.255.1', '255.255.255.252')
+            OR List os IPs provided in the <host_ip>/<netmask> format. E.g ["10.1.11.1/24", "12.12.12.12/28"]
+        :param dhcp: (Optional) Enable DHCP on the interface
+        :param ipv4_nat_inside: (Optional) Enable Inside NAT on IPv4
+        :param ipv6_address: (Optional) List of strs that stores IPv6 Addresses info in the
+            following format: 'FE81::1/64'
+        :param ipv6_nat_inside: (Optional) Enable Inside NAT on IPv6
+        """
+        payload = self._build_payload(
+            ifnum=ifnum, name=name,
+            enable=enable,
+            ipv4_address=ipv4_address,
+            dhcp=dhcp,
+            ipv4_nat_inside=ipv4_nat_inside,
+            ipv6_address=ipv6_address,
+            ipv6_nat_inside=ipv6_nat_inside
+        )
+        return self._post(f"{self.url_prefix}{ifnum}", payload)
+
+    def _build_payload(
+        self,
+        ifnum,
+        name=None,
+        enable=None,
+        ipv4_address=None,
+        dhcp=None,
+        ipv4_nat_inside=None,
+        ipv6_address=None,
+        ipv6_nat_inside=None
+    ):
+        rv = {
+            self.iftype: {
+                "ifnum": ifnum
+            }
+        }
+        if enable is not None:
+            rv[self.iftype].update(
+                {
+                    "action": "enable" if enable is True else "disable"
+                }
+            )
+        if name is not None:
+            rv[self.iftype].update(
+                {
+                    "name": name
+                }
+            )
+        if ipv4_address is not None and dhcp is None:
+            if isinstance(ipv4_address, tuple):
+                rv[self.iftype].update(
+                    {
+                        "ip": {
+                            "address-list": [
+                                {
+                                    "ipv4-address": ip,
+                                    "ipv4-netmask": netmask
+                                }
+                                for ip, netmask in ipv4_address
+                            ]
+                        }
+                    }
+                )
+            else:
+                rv[self.iftype].update(
+                    {
+                        "ip": {
+                            "address-list": [
+                                {
+                                    "ipv4-address": str(ip.ip),
+                                    "ipv4-netmask": str(ip.netmask)
+                                }
+                                for ip in map(lambda x: IPv4Interface(x), ipv4_address)
+                            ]
+                        }
+                    }
+                )
+            if ipv4_nat_inside is not None:
+                rv[self.iftype]['ip'].update(
+                    {
+                        "inside": 1 if ipv4_nat_inside is True else 0
+                    }
+                )
+        elif ipv4_address is None and dhcp is not None:
+            rv[self.iftype].update(
+                {
+                    "ip": {
+                        "dhcp": 1 if dhcp is True else 0
+                    }
+                }
+            )
+        if ipv6_address is not None:
+            rv[self.iftype].update(
+                {
+                    "ipv6": {
+                        "address-list": [
+                            {
+                                "ipv6-addr": ipv6,
+                            }
+                            for ipv6 in ipv6_address
+                        ],
+                    }
+                }
+            )
+            if ipv6_nat_inside is not None:
+                rv[self.iftype]['ipv6'].update(
+                    {
+                        "inside": 1 if ipv4_nat_inside is True else 0
+                    }
+                )
         return rv

--- a/acos_client/v30/router/__init__.py
+++ b/acos_client/v30/router/__init__.py
@@ -1,0 +1,34 @@
+from ..base import BaseV30
+from acos_client.v30.router.bgp import Bgp
+
+
+class Router(BaseV30):
+    def __str__(self):
+        return f"Router: {vars(self)}"
+
+    @property
+    def bgp(self) -> Bgp:
+        return Bgp(client=self.client)
+
+    @property
+    def isis(self):
+        pass
+
+    @property
+    def log(self):
+        pass
+
+    @property
+    def ospf(self):
+        pass
+
+    @property
+    def rip(self):
+        pass
+
+    @property
+    def ipv6(self):
+        pass
+
+    def all(self):
+        return self._get("/router/")

--- a/acos_client/v30/router/bgp.py
+++ b/acos_client/v30/router/bgp.py
@@ -1,0 +1,676 @@
+from ..base import BaseV30
+from .utils import create_route_map_structure
+
+from pprint import pprint
+
+
+class BgpBase(BaseV30):
+
+    def __init__(self, client):
+        super(BgpBase, self).__init__(client=client)
+        self.url_prefix = "/router/bgp/"
+        self.url_suffix = ""
+
+    def get_list(self, asn):
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        print(f"GET List URL: {_url}")
+        return self._get(_url)
+
+    def get(self, asn, key=None):
+        key = key if key is not None else ""
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        _url = f"{_url}{key}"
+        print(f"GET URL: {_url}")
+        return self._get(_url)
+
+    def delete(self, asn, key):
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        _url = f"{_url}{key}"
+        print(f"DELETE URL: {_url}")
+        return self._delete(_url)
+
+
+class NeighborIPv4(BgpBase):
+
+    def __init__(self, client):
+        super(NeighborIPv4, self).__init__(client=client)
+        self.url_suffix = "neighbor/ipv4-neighbor/"
+
+    def create(
+        self,
+        ip, asn,
+        bfd=None, description=None,
+        activate=None, multihop=None,
+        rm_in=None, rm_out=None,
+        peer_group_name=None, remote_as=None,
+        send_community=None, shutdown=None
+    ):
+        """
+        Create IPv4 BGP neighbor
+        :param ip: Neighbor IP Address
+        :param asn: Local BGP ASN
+        :param bfd: Enable BFP
+        :param description: Description for the neighbor
+        :param activate: Activate/DeActivate neighbor
+        :param multihop: Enable BGP multi-hp
+        :param rm_in: Specify inbound RouteMap
+        :param rm_out: Specify outbound RouteMap
+        :param peer_group_name: Assign the neighbor to a peer
+            group
+        :param send_community: Secify where to send commnunity
+            Allowed values: "both", "none", "standard", "extended"
+        :param remote_as: Specify neighbor remote AS number
+        :param shutdown: Shutdown BGP neighbour
+        :return Dict:
+        """
+        payload = self._build_payload(
+            ip=ip, bfd=bfd, description=description,
+            activate=activate, multihop=multihop,
+            rm_in=rm_in, rm_out=rm_out,
+            peer_group_name=peer_group_name,
+            send_community=send_community,
+            remote_as=remote_as,
+            shutdown=shutdown
+        )
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        print(f"URL NeighborIPv4 Create: {_url}")
+        return self._post(_url, payload)
+
+    def update(
+        self,
+        ip, asn,
+        bfd=None, description=None,
+        activate=None, multihop=None,
+        rm_in=None, rm_out=None,
+        peer_group_name=None, remote_as=None,
+        send_community=None, shutdown=None
+    ):
+        """
+        Update IPv4 neighbor
+        :param ip: Neighbor IP Address
+        :param asn: Local BGP ASN
+        :param bfd: Enable BFP
+        :param description: Description for the neighbor
+        :param activate: Activate/DeActivate neighbor
+        :param multihop: Enable BGP multi-hp
+        :param rm_in: Specify inbound RouteMap
+        :param rm_out: Specify outbound RouteMap
+        :param remote_as: Specify neighbor remote AS number
+        :param peer_group_name: Assign the neighbor to a peer
+            group
+        :param send_community: Secify where to send commnunity
+            Allowed values: "both", "none", "standard", "extended"
+        :param shutdown: Shutdown BGP neighbour
+        :return Dict:
+        """
+        payload = self._build_payload(
+            ip=ip, bfd=bfd, description=description,
+            activate=activate, multihop=multihop,
+            rm_in=rm_in, rm_out=rm_out,
+            peer_group_name=peer_group_name,
+            remote_as=remote_as,
+            send_community=send_community,
+            shutdown=shutdown
+        )
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        pprint(f"Url NeighborIPv4 Update: {_url}")
+        return self._post(f"{_url}{ip}", payload)
+
+    @staticmethod
+    def _build_payload(
+        ip,
+        bfd=None, description=None,
+        activate=None, multihop=None,
+        rm_in=None, rm_out=None,
+        peer_group_name=None, remote_as=None,
+        send_community=None, shutdown=None
+    ):
+        rv = dict()
+        rv['neighbor-ipv4'] = ip
+        if bfd is not None:
+            rv['bfd'] = 1 if bfd is True else 0
+        if description is not None:
+            rv['description'] = description
+        if activate is not None:
+            rv['activate'] = 1 if activate is True else 0
+        if peer_group_name is not None:
+            rv['peer-group-name'] = peer_group_name
+        if shutdown is not None:
+            rv['shutdown'] = 1 if shutdown is True else 0
+        if multihop is not None:
+            rv['ebgp-multihop'] = 1 if multihop is True else 0
+        if remote_as is not None:
+            rv['nbr-remote-as'] = remote_as
+        if send_community is not None:
+            if send_community not in ["both", "none", "standard", "extended"]:
+                raise ValueError(
+                    f"send_community val {send_community} not in accepted values: both, none, standard, extended"
+                )
+            rv['send-community-val'] = send_community
+        if rm_in is not None or rm_out is not None:
+            rv['neighbor-route-map-lists'] = create_route_map_structure(rm_in=rm_in, rm_out=rm_out)
+        return {
+            "ipv4-neighbor": rv
+        }
+
+
+class NeighborIPv6(BgpBase):
+
+    def __init__(self, client):
+        super(NeighborIPv6, self).__init__(client=client)
+        self.url_suffix = "neighbor/ipv6-neighbor/"
+
+    def create(
+        self,
+        ip, asn,
+        bfd=None, description=None,
+        activate=None, multihop=None,
+        rm_in=None, rm_out=None,
+        peer_group_name=None, remote_as=None,
+        send_community=None, shutdown=None
+    ):
+        """
+        Create IPv4 BGP neighbor
+        :param ip: Neighbor IP Address
+        :param asn: Local BGP ASN
+        :param bfd: Enable BFP
+        :param description: Description for the neighbor
+        :param activate: Activate/DeActivate neighbor
+        :param multihop: Enable BGP multi-hp
+        :param rm_in: Specify inbound RouteMap
+        :param rm_out: Specify outbound RouteMap
+        :param peer_group_name: Assign the neighbor to a peer
+            group
+        :param send_community: Secify where to send commnunity
+            Allowed values: "both", "none", "standard", "extended"
+        :param remote_as: Specify neighbor remote AS number
+        :param shutdown: Shutdown BGP neighbour
+        :return Dict:
+        """
+        payload = self._build_payload(
+            ip=ip, bfd=bfd, description=description,
+            activate=activate, multihop=multihop,
+            rm_in=rm_in, rm_out=rm_out,
+            peer_group_name=peer_group_name,
+            send_community=send_community,
+            remote_as=remote_as,
+            shutdown=shutdown
+        )
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        print(f"URL NeighborIPv4 Create: {_url}")
+        return self._post(_url, payload)
+
+    def update(
+        self,
+        ip, asn,
+        bfd=None, description=None,
+        activate=None, multihop=None,
+        rm_in=None, rm_out=None,
+        peer_group_name=None, remote_as=None,
+        send_community=None, shutdown=None
+    ):
+        """
+        Update IPv4 neighbor
+        :param ip: Neighbor IP Address
+        :param asn: Local BGP ASN
+        :param bfd: Enable BFP
+        :param description: Description for the neighbor
+        :param activate: Activate/DeActivate neighbor
+        :param multihop: Enable BGP multi-hp
+        :param rm_in: Specify inbound RouteMap
+        :param rm_out: Specify outbound RouteMap
+        :param remote_as: Specify neighbor remote AS number
+        :param peer_group_name: Assign the neighbor to a peer
+            group
+        :param send_community: Secify where to send commnunity
+            Allowed values: "both", "none", "standard", "extended"
+        :param shutdown: Shutdown BGP neighbour
+        :return Dict:
+        """
+        payload = self._build_payload(
+            ip=ip, bfd=bfd, description=description,
+            activate=activate, multihop=multihop,
+            rm_in=rm_in, rm_out=rm_out,
+            peer_group_name=peer_group_name,
+            remote_as=remote_as,
+            send_community=send_community,
+            shutdown=shutdown
+        )
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        pprint(f"Url NeighborIPv4 Update: {_url}")
+        return self._post(f"{_url}{ip}", payload)
+
+    @staticmethod
+    def _build_payload(
+        ip,
+        bfd=None, description=None,
+        activate=None, multihop=None,
+        rm_in=None, rm_out=None,
+        peer_group_name=None, remote_as=None,
+        send_community=None, shutdown=None
+    ):
+        rv = dict()
+        rv['neighbor-ipv6'] = ip
+        if bfd is not None:
+            rv['bfd'] = 1 if bfd is True else 0
+        if description is not None:
+            rv['description'] = description
+        if activate is not None:
+            rv['activate'] = 1 if activate is True else 0
+        if peer_group_name is not None:
+            rv['peer-group-name'] = peer_group_name
+        if shutdown is not None:
+            rv['shutdown'] = 1 if shutdown is True else 0
+        if multihop is not None:
+            rv['ebgp-multihop'] = 1 if multihop is True else 0
+        if remote_as is not None:
+            rv['nbr-remote-as'] = remote_as
+        if send_community is not None:
+            if send_community not in ["both", "none", "standard", "extended"]:
+                raise ValueError(
+                    f"send_community val {send_community} not in accepted values: both, none, standard, extended"
+                )
+            rv['send-community-val'] = send_community
+        if rm_in is not None or rm_out is not None:
+            rv['neighbor-route-map-lists'] = create_route_map_structure(rm_in=rm_in, rm_out=rm_out)
+        return {
+            "ipv6-neighbor": rv
+        }
+
+
+class PeerGroupIPv4Neighbor(BgpBase):
+
+    def __init__(self, client):
+        super(PeerGroupIPv4Neighbor, self).__init__(client=client)
+        self.url_suffix = f"neighbor/peer-group-neighbor/"
+
+    def create(
+        self,
+        asn,
+        name=None, remote_as=None,
+        bfd=None, route_refresh=None,
+        activate=None, multihop=None,
+        shutdown=None, next_hop_self=None,
+        rm_in=None, rm_out=None,
+        send_community=None,
+        inbound=None
+    ):
+        """
+        Create IPv4 neighbor peer-group
+
+        :param name: Peer-group name
+        :param asn: Local BGP ASN
+        :param bfd: Enable BFP
+        :param remote_as: Specify remote AS number
+        :param activate: Activate/DeActivate neighbor
+        :param route_refresh: Enable route-refresh
+        :param shutdown: Shutdown peer-group
+        :param multihop: Enable BGP multi-hp
+        :param rm_in: Specify inbound RouteMap
+        :param rm_out: Specify outbound RouteMap
+        :param next_hop_self: Enable next-hop-self
+        :param send_community: Specify where to send community
+            Allowed values: "both", "none", "standard", "extended"
+        :param inbound: Allow inbound soft reconfiguration for this neighbor
+        :return Dict:
+        """
+        payload = self._build_payload(
+            name=name, remote_as=remote_as, bfd=bfd,
+            route_refresh=route_refresh, activate=activate, multihop=multihop,
+            shutdown=shutdown, next_hop_self=next_hop_self,
+            rm_in=rm_in, rm_out=rm_out, send_community=send_community,
+            inbound=inbound
+        )
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        return self._post(_url, payload)
+
+    def update(
+        self,
+        asn,
+        name=None, remote_as=None,
+        bfd=None, route_refresh=None,
+        activate=None, multihop=None,
+        shutdown=None, next_hop_self=None,
+        rm_in=None, rm_out=None,
+        send_community=None,
+        inbound=None
+    ):
+        """
+        Update IPv4 neighbor peer-group
+
+        :param name: Peer-group name
+        :param asn: Local BGP ASN
+        :param bfd: Enable BFP
+        :param remote_as: Specify remote AS number
+        :param activate: Activate/DeActivate neighbor
+        :param route_refresh: Enable route-refresh
+        :param shutdown: Shutdown peer-group
+        :param multihop: Enable BGP multi-hp
+        :param rm_in: Specify inbound RouteMap
+        :param rm_out: Specify outbound RouteMap
+        :param next_hop_self: Enable next-hop-self
+        :param send_community: Specify where to send community
+            Allowed values: "both", "none", "standard", "extended"
+        :param inbound: Allow inbound soft reconfiguration for this neighbor
+        :return Dict:
+        """
+        payload = self._build_payload(
+            name=name, remote_as=remote_as, bfd=bfd,
+            route_refresh=route_refresh, activate=activate, multihop=multihop,
+            shutdown=shutdown, next_hop_self=next_hop_self,
+            rm_in=rm_in, rm_out=rm_out, send_community=send_community,
+            inbound=inbound
+        )
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        return self._post(f"{_url}{name}", payload)
+
+    @staticmethod
+    def _build_payload(
+        name=None, remote_as=None,
+        bfd=None, route_refresh=None,
+        activate=None, multihop=None,
+        shutdown=None, next_hop_self=None,
+        rm_in=None, rm_out=None,
+        send_community=None,
+        inbound=None
+    ):
+        rv = {
+            'peer-group-key': 1,
+            'activate': 1,
+            'allowas-in': 0,
+            'dynamic': 0,
+            'route-refresh': 1,
+            'extended-nexthop': 0,
+            'collide-established': 0,
+            'default-originate': 0,
+            'disallow-infinite-holdtime': 0,
+            'dont-capability-negotiate': 0,
+            'ebgp-multihop': 0,
+            'enforce-multihop': 0,
+            'bfd': 0,
+            'maximum-prefix': 128,
+            'next-hop-self': 0,
+            'override-capability': 0,
+            'passive': 0,
+            'remove-private-as': 0,
+            'send-community-val': 'both',
+            'inbound': 0,
+            'shutdown': 0,
+            'strict-capability-match': 0,
+            'timers-keepalive': 30,
+            'timers-holdtime': 90,
+            'weight': 0,
+        }
+        if name is not None:
+            rv['peer-group'] = name
+        if remote_as is not None:
+            rv['peer-group-remote-as'] = remote_as
+        if bfd is not None:
+            rv['bfd'] = 1 if bfd is True else 0
+        if send_community is not None:
+            if send_community not in ["both", "none", "standard", "extended"]:
+                raise ValueError(
+                    f"send_community val {send_community} not in accepted values: both, none, standard, extended"
+                )
+            rv['send-community-val'] = send_community
+        if activate is not None:
+            rv['activate'] = 1 if activate is True else 0
+        if shutdown is not None:
+            rv['shutdown'] = 1 if shutdown is True else 0
+        if multihop is not None:
+            rv['ebgp-multihop'] = 1 if multihop is True else 0
+        if route_refresh is not None:
+            rv['route-refresh'] = 1 if route_refresh is True else 0
+        if next_hop_self is not None:
+            rv['next-hop-self'] = 1 if next_hop_self is True else 0
+        if inbound is not None:
+            rv['inbound'] = 1 if next_hop_self is True else 0
+        if rm_in is not None or rm_out is not None:
+            rv['neighbor-route-map-lists'] = create_route_map_structure(rm_in=rm_in, rm_out=rm_out)
+        # return rv
+        return {
+            "peer-group-neighbor": rv
+        }
+
+
+class NeighborIpv6(BgpBase):
+
+    def __init__(self, client):
+        super(NeighborIpv6, self).__init__(client=client)
+        self.url_suffix = f"address-family/ipv6/neighbor/ipv6-neighbor/"
+
+    def create(
+        self,
+        ipv6, asn,
+        send_community=None,
+        next_hop_self=None,
+        activate=None,
+        rm_in=None, rm_out=None,
+        peer_group_name=None,
+    ):
+        """
+        Create IPv6 neighbor
+
+        :param ipv6: Neighbor IP Address
+        :param asn: Local BGP ASN
+        :param activate: Activate/DeActivate neighbor
+        :param rm_in: Specify inbound RouteMap
+        :param rm_out: Specify outbound RouteMap
+        :param next_hop_self: Enable next-hop-self
+        :param peer_group_name: Assign the neighbor to a peer
+            group
+        :param send_community: Specify where to send community
+            Allowed values: "both", "none", "standard", "extended"
+        :return Dict:
+        """
+        payload = self._build_payload(
+            ipv6=ipv6, send_community=send_community,
+            next_hop_self=next_hop_self, activate=activate,
+            rm_out=rm_out, rm_in=rm_in, peer_group_name=peer_group_name
+        )
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        print(f"URL NeighborIpv6 Create: {_url}")
+        return self._post(_url, payload)
+
+    def update(
+        self,
+        ipv6, asn,
+        send_community=None,
+        next_hop_self=None,
+        activate=None,
+        rm_in=None, rm_out=None,
+        peer_group_name=None,
+    ):
+        """
+        Update IPv6 neighbor
+
+        :param ipv6: Neighbor IP Address
+        :param asn: Local BGP ASN
+        :param activate: Activate/DeActivate neighbor
+        :param rm_in: Specify inbound RouteMap
+        :param rm_out: Specify outbound RouteMap
+        :param next_hop_self: Enable next-hop-self
+        :param peer_group_name: Assign the neighbor to a peer
+            group
+        :param send_community: Specify where to send community
+            Allowed values: "both", "none", "standard", "extended"
+        :return Dict:
+        """
+        payload = self._build_payload(
+            ipv6=ipv6, send_community=send_community,
+            next_hop_self=next_hop_self, activate=activate,
+            rm_out=rm_out, rm_in=rm_in, peer_group_name=peer_group_name
+        )
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        print(f"URL NeighborIpv6 Update: {_url}{ipv6}")
+        return self._post(f"{_url}{ipv6}", payload)
+
+    @staticmethod
+    def _build_payload(
+        ipv6,
+        send_community=None,
+        next_hop_self=None,
+        activate=None,
+        rm_in=None, rm_out=None,
+        peer_group_name=None,
+    ):
+        rv = dict()
+        rv['neighbor-ipv6'] = ipv6
+        if send_community is not None:
+            if send_community not in ["both", "none", "standard", "extended"]:
+                raise ValueError(
+                    f"send_community val {send_community} not in accepted values: both, none, standard, extended"
+                )
+            rv['send-community-val'] = send_community
+        if next_hop_self is not None:
+            rv['next-hop-self'] = 1 if next_hop_self is True else 0
+        if activate is not None:
+            rv['activate'] = 1 if activate is True else 0
+        if rm_in is not None or rm_out is not None:
+            rv['neighbor-route-map-lists'] = create_route_map_structure(rm_in=rm_in, rm_out=rm_out)
+        if peer_group_name is not None:
+            rv['peer-group-name'] = peer_group_name
+        return {
+            "ipv6-neighbor": rv
+        }
+
+
+class PeerGroupIpv6(BgpBase):
+
+    def __init__(self, client):
+        super(PeerGroupIpv6, self).__init__(client)
+        self.url_suffix = f"address-family/ipv6/neighbor/peer-group-neighbor/"
+
+    def create(
+        self,
+        name, asn, activate=None,
+        send_community=None,
+        next_hop_self=None,
+        max_prefix=None,
+        inbound=None
+    ):
+        """
+        For IPv6, in order to use a peergroup that you created before,
+        you need to activate first that peer-group into IPv6 AF container
+
+        :param name: Peer-group name
+        :param asn: Local BGP AS Number
+        :param activate: Activate/DeActivate neighbor
+        :param max_prefix: Maximum number of prefix accept from this pee
+        :param next_hop_self: Enable next-hop-self
+        :param send_community: Specify where to send community
+            Allowed values: "both", "none", "standard", "extended"
+        :param inbound: Allow inbound soft reconfiguration for this neighbor
+        :return Dict:
+        """
+        payload = self._build_payload(
+            name=name, activate=activate,
+            send_community=send_community, next_hop_self=next_hop_self,
+            max_prefix=max_prefix, inbound=inbound
+        )
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        return self._post(_url, payload)
+
+    def update(
+        self,
+        name, asn, activate=None,
+        send_community=None,
+        next_hop_self=None,
+        max_prefix=None,
+        inbound=None
+    ):
+        """
+        Update IPv6 peer-group values
+
+        :param name: Peer-group name
+        :param asn: Local BGP AS Number
+        :param activate: Activate/DeActivate neighbor
+        :param max_prefix: Maximum number of prefix accept from this pee
+        :param next_hop_self: Enable next-hop-self
+        :param send_community: Specify where to send community
+            Allowed values: "both", "none", "standard", "extended"
+        :param inbound: Allow inbound soft reconfiguration for this neighbor
+        :return Dict:
+        """
+        payload = self._build_payload(
+            name=name, activate=activate,
+            send_community=send_community, next_hop_self=next_hop_self,
+            max_prefix=max_prefix, inbound=inbound
+        )
+        _url = self._build_url(middle=asn, suffix=self.url_suffix, ends_with_separator=True)
+        return self._post(f"{_url}{name}", payload)
+
+    @staticmethod
+    def _build_payload(
+        name, activate=None,
+        send_community=None,
+        next_hop_self=None,
+        max_prefix=None,
+        inbound=None
+    ):
+        rv = {'allowas-in': 0, 'default-originate': 0, 'inbound': 0, 'maximum-prefix': 128, 'next-hop-self': 0,
+              'peer-group': name, 'remove-private-as': 0, 'send-community-val': 'both'}
+        if activate is not None:
+            rv['activate'] = 1 if activate is True else 0
+        if send_community is not None:
+            if send_community not in ["both", "none", "standard", "extended"]:
+                raise ValueError(
+                    f"send_community val {send_community} not in accepted values: both, none, standard, extended"
+                )
+            rv['send-community-val'] = send_community
+        if next_hop_self is not None:
+            rv['next-hop-self'] = 1 if next_hop_self is True else 0
+        if max_prefix is not None:
+            rv['maximum-prefix'] = max_prefix
+        if inbound is not None:
+            rv['inbound'] = 1 if next_hop_self is True else 0
+        return {
+            "peer-group-neighbor": rv
+        }
+
+
+class Neighbor(BgpBase):
+
+    def __init__(self, client):
+        super(Neighbor, self).__init__(client=client)
+        self.url_suffix = "neighbor/"
+
+    @property
+    def ipv4_neighbor(self):
+        return NeighborIPv4(self.client)
+
+    @property
+    def ipv6_neighbor(self):
+        return NeighborIPv6(self.client)
+
+    @property
+    def peer_group(self):
+        return PeerGroupIPv4Neighbor(self.client)
+
+
+class AddressFamilyIPv6(BgpBase):
+    def __init__(self, client):
+        super(AddressFamilyIPv6, self).__init__(client=client)
+        self.url_suffix = "address-family/"
+
+    @property
+    def ipv6_neighbor(self):
+        return NeighborIpv6(self.client)
+
+    @property
+    def peer_group(self):
+        return PeerGroupIpv6(self.client)
+
+
+class Bgp(BgpBase):
+
+    def __init__(self, client):
+        super(Bgp, self).__init__(client=client)
+
+    @property
+    def neighbor(self):
+        return Neighbor(self.client)
+
+    @property
+    def address_family(self):
+        return AddressFamilyIPv6(self.client)

--- a/acos_client/v30/router/utils.py
+++ b/acos_client/v30/router/utils.py
@@ -1,0 +1,17 @@
+from typing import List, Optional
+
+
+def create_route_map_structure(rm_in: Optional[str] = None, rm_out: Optional[str] = None) -> List:
+    """
+    Helper function for creating the Route-Map structure that can be applied
+    in multiple locations, like IPv4 Neighbour, Ipv6 Neighbour, etc
+    :param rm_in: Name of the inbound Route-Map
+    :param rm_out: Name of the outbound Route-Map
+    :returns: List
+    """
+    rm_list = list()
+    if rm_out is not None:
+        rm_list.append({"nbr-rmap-direction": "out", "nbr-route-map": rm_out})
+    if rm_in is not None:
+        rm_list.append({"nbr-rmap-direction": "in", "nbr-route-map": rm_in})
+    return rm_list

--- a/acos_client/v30/slb/__init__.py
+++ b/acos_client/v30/slb/__init__.py
@@ -19,8 +19,8 @@ from acos_client.v30.slb.common import SLBCommon
 from acos_client.v30.slb.hm import HealthMonitor
 from acos_client.v30.slb.server import Server
 from acos_client.v30.slb.service_group import ServiceGroup
-from acos_client.v30.slb.template import Template
 from acos_client.v30.slb.tcp_proxy import TcpProxy
+from acos_client.v30.slb.template import Template
 from acos_client.v30.slb.virtual_server import VirtualServer
 
 

--- a/acos_client/v30/slb/tcp_proxy.py
+++ b/acos_client/v30/slb/tcp_proxy.py
@@ -14,8 +14,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import six
-
 from acos_client import errors as acos_errors
 from acos_client.v30 import base
 
@@ -41,7 +39,7 @@ class TcpProxy(base.BaseV30):
     def _set(self, name, version, **kwargs):
 
         params = {
-            "tcp-proxy":{
+            "tcp-proxy": {
                 "name": name,
                 "proxy-header": {
                     "proxy-header-action": "insert",

--- a/acos_client/version.py
+++ b/acos_client/version.py
@@ -12,4 +12,4 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-VERSION = '2.9.1'
+VERSION = '2.10.0'


### PR DESCRIPTION
### Reason
We added a list of feature that we needed for our project that also involves touching A10 devices. Some needed parts of configuration were not abstracted in the `acos-clinet`.

### Updates added
- Added InterfaceVE object for CRUD on Virtual Ethernet interfaces for v30
- Added ClassList object for CRUD on Class Lists for v30
- Added Router/BGP object for CRUD on bgp section for v30
- Added more unittests to cover the new addition