### PR TITLE
[STACK-3594] [STACK-3604] [IPv6 support][Rack flow] Failed to create IPv6 loadbalancer when IPv4 loadbalancer and member already exists on the vThunder.

### DIFF
--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -73,7 +73,7 @@ class Action(base.BaseV30):
                     'ipv6': {'address-list': address_list, 'ipv6-enable': 1}}}
 
         url = "/interface/ethernet/" + str(interface)
-        self._post(url, data)
+        self._put(url, data)
 
     def reboot(self):
         self._post("/reboot", "")


### PR DESCRIPTION
## Description

If Bug Fix:
- Severity Level: High
- [IPv6 support][Rack flow] Failed to create IPv6 loadbalancer when IPv4 loadbalancer and member already exists on the vThunder.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-3594
https://a10networks.atlassian.net/browse/STACK-3604

## Technical Approach
- Fixed VRID issues
- Fixed interface attachment and detachment issues.